### PR TITLE
Mark readme and contributing as generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+/contributing/* linguist-generated=true
+/README.md linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto eol=lf
-/contributing/* linguist-generated=true
+/contributors/* linguist-generated=true
 /README.md linguist-generated=true


### PR DESCRIPTION
This PR attempts to cleanup the diffs on this repo. This is best illustrated with the following image from a recent commit (fec3da0d20d17e1ecae6d7c8547b0c13970a06d3). Only the blue part is relevant code changes. Note that you will still be able to view the diffs for these contributor files. [More info](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-how-changed-files-appear-on-github).
<img width="194" alt="chrome_bS5rOBfhmb" src="https://user-images.githubusercontent.com/17352009/95522196-b97e3800-09cb-11eb-989e-7a5916e5c1e1.png">

