### PR TITLE
Update json localization

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
         "watch": "tsc -w"
     },
     "dependencies": {
-        "@mcschema/core": "^0.9.6",
-        "@mcschema/java-1.16": "^0.5.10",
+        "@mcschema/core": "^0.11.0",
+        "@mcschema/java-1.16": "^0.5.12",
         "@mcschema/locales": "^0.1.11",
         "appdata-path": "^1.0.0",
         "clone": "^2.1.2",

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,16 +1,16 @@
-import { LOCALES as JsonLocales } from '@mcschema/core'
 import { Locale } from '../types/Locale'
 import AmericanEnglish from './en.json'
+import JsonAmericanEnglish from '@mcschema/locales/src/en.json'
 
 const Locales: {
     en: Locale,
     [key: string]: Locale
 } = {
-    '': AmericanEnglish,
-    en: AmericanEnglish
+    en: { ...JsonAmericanEnglish, ...AmericanEnglish }
 }
 
 let language = ''
+Locales[language] = Locales.en
 
 /* istanbul ignore next */
 export function locale(key: string, ...params: any[]) {
@@ -29,14 +29,26 @@ export function resolveLocalePlaceholders(val: string | undefined, params?: stri
     })
 }
 
+export function segmentedLocale(segments: string[], params?: string[], depth = 5, minDepth = 1): string | undefined {
+    return [language, 'en'].reduce((prev, code) => {
+        if (prev !== undefined) return prev
+
+        const array = segments.slice(-depth);
+        while (array.length >= minDepth) {
+            const locale = resolveLocalePlaceholders(Locales[code][array.join('.')], params)
+            if (locale !== undefined) return locale
+            array.shift()
+        }
+
+        return undefined
+    }, undefined)
+}
+
 async function setupLanguage(code: string) {
     const locale = await import(`./${code}.json`)
-    Locales[code] = locale
-    language = code
-
     const jsonLocale = await import(`@mcschema/locales/src/${code}.json`)
-    JsonLocales.register(code, jsonLocale)
-    JsonLocales.language = code
+    Locales[code] = { ...jsonLocale, ...locale }
+    language = code
 
     console.info(`[I18N] Set to “${code}”.`)
 }


### PR DESCRIPTION
Required changes for to be able to upgrade `@mcschema/core` to `0.11.0`.

The language server now needs to handle localization itself since it has been removed from @mcschema/core. But since it already had localization I decided to simply merge the objects. *I assume there are no conflicting translation keys?*

This also adds a `segmentedLocale` exported function in `locales/index.ts`. This is the equivalent of `Path.strictLocale`.