### PR TITLE
:recycle: Suggestions to replace the extname function

### DIFF
--- a/src/nodes/IdentityNode.ts
+++ b/src/nodes/IdentityNode.ts
@@ -211,7 +211,7 @@ export class IdentityNode extends ArgumentNode {
     }
 
     /**
-     * 
+     *
      * @param rel The relative path from the workspace. Returns `undefined` if the path is in an invalid
      * datapack category.
      */
@@ -222,7 +222,7 @@ export class IdentityNode extends ArgumentNode {
         }
         rel = path.normalize(rel)
         const segs = rel.split(/[/\\]/)
-        const ext = path.extname(rel)
+        const ext = rel.match(/(?<=\.)[^./\\]*?$/)?.pop() ?? ''
         const side = segs[0]
         if (side === 'data') {
             for (const type of Object.keys(PathPatterns)) {


### PR DESCRIPTION
path.extname() should not be used for files with only an extension, as it will not be recognized as an extension.
There is currently no implementation of referencing ext in IdentityNode.fromRel(), but this is to prevent future bugs.
refer: https://nodejs.org/api/path.html#path_path_extname_path