### PR TITLE
⏪️ Revert "💚 Use OpenID Connect to publish to npm"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
 permissions:
   contents: write
-  id-token: write
 env:
   BOT_EMAIL: ${{ secrets.BOT_EMAIL }}
   BOT_NAME: ${{ secrets.BOT_NAME }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   OVSX_PAT: ${{ secrets.OVSX_PAT }}
   VSCE_PAT: ${{ secrets.VSCE_PAT }}
 jobs:


### PR DESCRIPTION
This reverts commit b22f61018184ede758facd6ff5f43624b270a503.

Feel free to merge this if the release process is broken for the npm packages to revert back to using NPM_TOKEN, and feel free to close this if everything works fine.