### PR TITLE
💚 Fix dry run releases

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "dependencies": {
     "base64-arraybuffer": "^1.0.2",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run",
+    "release:dry": "npm publish --tag release --dry-run",
     "start": "node lib/index.js"
   },
   "engines": {

--- a/packages/java-edition/package.json
+++ b/packages/java-edition/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run",
+    "release:dry": "npm publish --tag release --dry-run",
     "build": "wireit",
     "build:dev": "wireit"
   },

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "wireit",
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "wireit": {
     "build": {

--- a/packages/mcdoc-cli/package.json
+++ b/packages/mcdoc-cli/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run",
+    "release:dry": "npm publish --tag release --dry-run",
     "setup": "git clone https://github.com/SpyglassMC/vanilla-mcdoc",
     "test": "rm -rf out/generated/module/* && cd vanilla-mcdoc && git pull && cd .. && tsc -b && node lib/index.js generate vanilla-mcdoc/ -l -m -p"
   },

--- a/packages/mcdoc/package.json
+++ b/packages/mcdoc/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mcfunction/package.json
+++ b/packages/mcfunction/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nbt/package.json
+++ b/packages/nbt/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run"
+    "release:dry": "npm publish --tag release --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/web-api-server/package.json
+++ b/packages/web-api-server/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --dry-run",
+    "release:dry": "npm publish --tag release --dry-run",
     "start": "./bin/server.js | pino-pretty"
   },
   "dependencies": {


### PR DESCRIPTION
npm@11 no longer applies the default `latest` tag if the semver in package.json is a pre-release version (which it is in dry-run modes). I've added an explicit `--tag latest` argument to the dry run publish commands.

See https://docs.npmjs.com/cli/v11/using-npm/changelog#%EF%B8%8F-breaking-changes-1