### PR TITLE
💚 Fix typo in '--tag latest'

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "dependencies": {
     "base64-arraybuffer": "^1.0.2",

--- a/packages/discord-bot/package.json
+++ b/packages/discord-bot/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run",
+    "release:dry": "npm publish --tag latest --dry-run",
     "start": "node lib/index.js"
   },
   "engines": {

--- a/packages/java-edition/package.json
+++ b/packages/java-edition/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run",
+    "release:dry": "npm publish --tag latest --dry-run",
     "build": "wireit",
     "build:dev": "wireit"
   },

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "wireit",
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "wireit": {
     "build": {

--- a/packages/mcdoc-cli/package.json
+++ b/packages/mcdoc-cli/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run",
+    "release:dry": "npm publish --tag latest --dry-run",
     "setup": "git clone https://github.com/SpyglassMC/vanilla-mcdoc",
     "test": "rm -rf out/generated/module/* && cd vanilla-mcdoc && git pull && cd .. && tsc -b && node lib/index.js generate vanilla-mcdoc/ -l -m -p"
   },

--- a/packages/mcdoc/package.json
+++ b/packages/mcdoc/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mcfunction/package.json
+++ b/packages/mcfunction/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nbt/package.json
+++ b/packages/nbt/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run"
+    "release:dry": "npm publish --tag latest --dry-run"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/web-api-server/package.json
+++ b/packages/web-api-server/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "release": "npm publish",
-    "release:dry": "npm publish --tag release --dry-run",
+    "release:dry": "npm publish --tag latest --dry-run",
     "start": "./bin/server.js | pino-pretty"
   },
   "dependencies": {


### PR DESCRIPTION
I'm a little silly. The default tag name used by npm publish is `latest`: https://docs.npmjs.com/adding-dist-tags-to-packages#:~:text=by%20default%2C%20running%20npm%20publish%20will%20tag%20your%20package%20with%20the%20latest%20dist-tag.