### PR TITLE
Fix config not being reloaded after saving

### DIFF
--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -516,7 +516,7 @@ export class ConfigService implements ExternalEventEmitter {
 		return ConfigService.merge(this.defaultConfig, ...overrides)
 	}
 
-	private static isConfigFile(this: void, uri: string): boolean {
+	public static isConfigFile(this: void, uri: string): boolean {
 		return ConfigService.ConfigFileNames.some((n) => uri.endsWith(`/${n}`))
 	}
 

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -962,7 +962,8 @@ export class Project implements ExternalEventEmitter {
 	 *                 its file extension.
 	 */
 	public shouldExclude(uri: string, language?: string): boolean {
-		return !this.isSupportedLanguage(uri, language) || this.isUserExcluded(uri)
+		return (!this.isSupportedLanguage(uri, language) && !ConfigService.isConfigFile(uri))
+			|| this.isUserExcluded(uri)
 	}
 
 	private isSupportedLanguage(uri: string, language?: string): boolean {


### PR DESCRIPTION
Currently, the language server has to be restarted in order to load changes from the config file. This is because the `ConfigService` uses the file watcher from `Project`, which filters for supported languages. Since there is no `spyglassrc` language and also the `jsonUriPredicate` doesn't match config files, it doesn't detect any changes to configs.

To fix that, this pull request just adds another check for config files to `Project.shouldExclude`. Don't know if you maybe want to go for a cleaner solution instead...