### PR TITLE
🧱 Disable contact form on Weblate

### DIFF
--- a/ansible/roles/weblate/templates/docker-compose.override.yml
+++ b/ansible/roles/weblate/templates/docker-compose.override.yml
@@ -7,6 +7,9 @@ services:
       WEBLATE_ADMIN_EMAIL: '{{ weblate_admin_email }}'
       WEBLATE_ADMIN_NAME: '{{ weblate_admin_name }}'
 
+      # Contact form
+      WEBLATE_CONTACT_FORM: disabled
+
       # Email
       WEBLATE_EMAIL_HOST: '{{ weblate_email_host }}'
       WEBLATE_EMAIL_PORT: '{{ weblate_email_port }}'


### PR DESCRIPTION
New option for Weblate 5.15:
https://docs.weblate.org/en/weblate-5.15/admin/config.html#std-setting-CONTACT_FORM