### PR TITLE
🐛 Don't show “expected nothing” if root type cannot be resolved

### DIFF
--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -206,6 +206,14 @@ export function typeDefinition<T>(
 		const validRootDefinitions = simplifiedRoot.kind === 'union'
 			? simplifiedRoot.members
 			: [simplifiedRoot]
+
+		if (
+			validRootDefinitions.length === 0
+			&& (typeDef.kind !== 'union' || typeDef.members.length > 0)
+		) {
+			validRootDefinitions.push({ kind: 'any' })
+		}
+
 		value.definitionsByParent = [{
 			parents: [],
 			keyDefinition: undefined,


### PR DESCRIPTION
Work towards #1938

> - We should have graceful fallback behaviors for any missing meta-resources.
>   - We would rather have no validations than false positives (full screens of nonsensical errors like "Expected nothing" is not acceptable)

With this change, in case the root type the mcdoc runtime checker is called with cannot be resolved, the `any` type will be used instead of empty union.

Usually in case something is not able to be resolved, an empty union is emitted, causing an “expected noting” error. In case this happens for the type runtime checker is called with, this will be replaced by the `any` type. Calling the runtime checker explicitly with an empty union will still produce “expected noting”, and in case a type that is referenced later cannot be resolved, “expected nothing” would still be emitted.

This disables all validations and completions for this case in a graceful way.