### PR TITLE
🐛 Replace isEquivalent with tryConvertTo

### DIFF
--- a/packages/json/src/checker/index.ts
+++ b/packages/json/src/checker/index.ts
@@ -24,25 +24,36 @@ export function index(
 			[{ originalNode: node, inferredType: inferType(node) }],
 			type,
 			mcdoc.runtime.checker.McdocCheckerContext.create(ctx, {
-				isEquivalent: (inferred, def) => {
-					switch (inferred.kind) {
-						case 'list':
-							return ['list', 'byte_array', 'int_array', 'long_array', 'tuple'].includes(
-								def.kind,
+				tryConvertTo: (node, target) => {
+					switch (node.type) {
+						case 'json:array':
+							switch (target.kind) {
+								case 'list':
+									return { kind: 'list', item: { kind: 'any' } }
+								case 'byte_array':
+								case 'int_array':
+								case 'long_array':
+									return { kind: target.kind }
+								case 'tuple':
+									return { kind: 'tuple', items: [] }
+							}
+							break
+						case 'json:number':
+							const literalValue = mcdoc.LiteralNumericValue.makeIfValid(
+								target.kind,
+								node.value.value,
+								true,
+								true,
 							)
-						case 'struct':
-							return def.kind === 'struct'
-						case 'byte':
-						case 'short':
-						case 'int':
-						case 'long':
-							return ['byte', 'short', 'int', 'long', 'float', 'double'].includes(def.kind)
-						case 'float':
-						case 'double':
-							return ['float', 'double'].includes(def.kind)
-						default:
-							return false
+							if (literalValue !== undefined) {
+								return { kind: 'literal', value: literalValue }
+							}
 					}
+					const inferred = inferType(node)
+					if (inferred.kind === target.kind) {
+						return inferred
+					}
+					return undefined
 				},
 				getChildren: node => {
 					if (node.type === 'json:array') {
@@ -116,7 +127,7 @@ export function index(
 	}
 }
 
-function inferType(node: JsonNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
+function inferType(node: JsonNode): mcdoc.runtime.checker.SimplifiedMcdocTypeNoUnion {
 	switch (node.type) {
 		case 'json:boolean':
 			return { kind: 'literal', value: { kind: 'boolean', value: node.value! } }

--- a/packages/json/src/checker/index.ts
+++ b/packages/json/src/checker/index.ts
@@ -49,10 +49,6 @@ export function index(
 								return { kind: 'literal', value: literalValue }
 							}
 					}
-					const inferred = inferType(node)
-					if (inferred.kind === target.kind) {
-						return inferred
-					}
 					return undefined
 				},
 				getChildren: node => {

--- a/packages/mcdoc/src/runtime/checker/context.ts
+++ b/packages/mcdoc/src/runtime/checker/context.ts
@@ -15,10 +15,10 @@ export interface RuntimePair<T> {
 	possibleValues: RuntimeNode<T>[]
 }
 
-export type NodeEquivalenceChecker = (
-	inferredNode: Exclude<SimplifiedMcdocTypeNoUnion, LiteralType | EnumType>,
+export type TypeConverter<T> = (
+	node: T,
 	definition: Exclude<SimplifiedMcdocTypeNoUnion, LiteralType | EnumType>,
-) => boolean
+) => SimplifiedMcdocTypeNoUnion | undefined
 
 export type TypeInfoAttacher<T> = (
 	node: T,
@@ -40,7 +40,7 @@ export type ErrorReporter<T> = (error: McdocRuntimeError<T>) => void
 export interface McdocCheckerContext<T> extends core.CheckerContext {
 	allowMissingKeys: boolean
 	requireCanonical: boolean
-	isEquivalent: NodeEquivalenceChecker
+	tryConvertTo: TypeConverter<T>
 	getChildren: ChildrenGetter<T>
 	reportError: ErrorReporter<T>
 	attachTypeInfo?: TypeInfoAttacher<T>
@@ -57,7 +57,7 @@ export namespace McdocCheckerContext {
 			...ctx,
 			allowMissingKeys: options.allowMissingKeys ?? false,
 			requireCanonical: options.requireCanonical ?? false,
-			isEquivalent: options.isEquivalent ?? (() => false),
+			tryConvertTo: options.tryConvertTo ?? (() => undefined),
 			getChildren: options.getChildren ?? (() => []),
 			reportError: options.reportError ?? (() => {}),
 			attachTypeInfo: options.attachTypeInfo,

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -26,7 +26,7 @@ import type {
 } from '../../type/index.js'
 import { McdocType, NumericRange } from '../../type/index.js'
 import { handleAttributes, shouldKeepAccordingToAttributeFilters } from '../attribute/index.js'
-import type { NodeEquivalenceChecker, RuntimeNode, RuntimePair, RuntimeUnion } from './context.js'
+import type { RuntimeNode, RuntimePair, RuntimeUnion, TypeConverter } from './context.js'
 import { McdocCheckerContext } from './context.js'
 import type { ErrorCondensingDefinition, McdocRuntimeError } from './error.js'
 import { condenseAndPropagate } from './error.js'
@@ -83,7 +83,7 @@ export function isAssignable(
 	assignValue: McdocType,
 	typeDef: McdocType,
 	ctx: CheckerContext,
-	isEquivalent?: NodeEquivalenceChecker,
+	convert?: TypeConverter<McdocType>,
 ): boolean {
 	if (
 		assignValue.kind === 'literal' && typeDef.kind === 'literal'
@@ -94,18 +94,27 @@ export function isAssignable(
 	}
 	let ans = true
 	const newCtx = McdocCheckerContext.create(ctx, {
-		isEquivalent,
+		tryConvertTo: convert,
 		getChildren: (_, d) => {
 			switch (d.kind) {
 				case 'list':
 					const vals = getPossibleTypes(d.item)
 					return [vals.map(v => ({ originalNode: v, inferredType: v }))]
 				case 'byte_array':
-					return [[{ originalNode: { kind: 'byte' }, inferredType: { kind: 'byte' } }]]
+					return [[{
+						originalNode: { kind: 'byte' },
+						inferredType: { kind: 'byte' },
+					}]] satisfies RuntimeUnion<McdocType>[]
 				case 'int_array':
-					return [[{ originalNode: { kind: 'int' }, inferredType: { kind: 'int' } }]]
+					return [[{
+						originalNode: { kind: 'int' },
+						inferredType: { kind: 'int' },
+					}]] satisfies RuntimeUnion<McdocType>[]
 				case 'long_array':
-					return [[{ originalNode: { kind: 'long' }, inferredType: { kind: 'long' } }]]
+					return [[{
+						originalNode: { kind: 'long' },
+						inferredType: { kind: 'long' },
+					}]] satisfies RuntimeUnion<McdocType>[]
 				case 'struct':
 					return d.fields.map(f => {
 						const vals = getPossibleTypes(f.type)
@@ -456,12 +465,15 @@ function checkShallowly<T>(
 	}
 
 	const typeDefValueType = getValueType(typeDef)
-	const runtimeValueType = getValueType(simplifiedInferred)
+	let runtimeValueType = getValueType(simplifiedInferred)
 
-	if (
-		runtimeValueType.kind !== typeDefValueType.kind
-		&& !ctx.isEquivalent(runtimeValueType, typeDefValueType)
-	) {
+	if (runtimeValueType.kind !== typeDefValueType.kind) {
+		simplifiedInferred = ctx.tryConvertTo(runtimeNode.originalNode, typeDefValueType)
+			?? simplifiedInferred
+		runtimeValueType = getValueType(simplifiedInferred)
+	}
+
+	if (runtimeValueType.kind !== typeDefValueType.kind) {
 		return {
 			childDefinitions,
 			errors: [{ kind: 'type_mismatch', node: runtimeNode, expected: [typeDef] }],
@@ -584,7 +596,10 @@ function checkShallowly<T>(
 								kvp.value.key.inferredType,
 								pair.key,
 								ctx,
-								ctx.isEquivalent,
+								(type, target) =>
+									type === kvp.value.key.inferredType
+										? ctx.tryConvertTo(kvp.value.key.originalNode, target)
+										: undefined,
 							)
 						) {
 							foundMatch = true
@@ -592,13 +607,22 @@ function checkShallowly<T>(
 						}
 					}
 					for (const kvp of literalKvps.entries()) {
+						const literalType = {
+							kind: 'literal',
+							value: { kind: 'string', value: kvp[0] },
+						} satisfies LiteralType
 						if (
 							(!kvp[1].definition || kvp[1].definition.keyType?.kind !== 'literal')
-							&& isAssignable(
-								{ kind: 'literal', value: { kind: 'string', value: kvp[0] } },
-								pair.key,
-								ctx,
-								ctx.isEquivalent,
+							&& kvp[1].values.some(v =>
+								isAssignable(
+									literalType,
+									pair.key,
+									ctx,
+									(type, target) =>
+										type === literalType
+											? ctx.tryConvertTo(v.pair.key.originalNode, target)
+											: undefined,
+								)
 							)
 						) {
 							foundMatch = true

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -607,10 +607,10 @@ function checkShallowly<T>(
 						}
 					}
 					for (const kvp of literalKvps.entries()) {
-						const literalType = {
+						const literalType: LiteralType = {
 							kind: 'literal',
 							value: { kind: 'string', value: kvp[0] },
-						} satisfies LiteralType
+						}
 						if (
 							(!kvp[1].definition || kvp[1].definition.keyType?.kind !== 'literal')
 							&& kvp[1].values.some(v =>

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -2,6 +2,7 @@ import type { FullResourceLocation } from '@spyglassmc/core'
 import { Arrayable, Dev, max, min, numericEquals } from '@spyglassmc/core'
 import type { EnumKind } from '../node/index.js'
 import { getRangeDelimiter, RangeKind } from '../node/index.js'
+import { numericType } from '../parser/index.js'
 
 export type Attributes = Attribute[]
 export namespace Attributes {
@@ -313,6 +314,49 @@ export interface LiteralNumericValue {
 export interface LiteralLongNumberValue {
 	kind: 'long'
 	value: bigint
+}
+export namespace LiteralNumericValue {
+	export function makeIfValid(
+		kind: string,
+		value: number | bigint,
+		allowInt: boolean = true,
+		allowFloat: boolean = true,
+	): LiteralNumericValue | LiteralLongNumberValue | undefined {
+		value = Number(value)
+		switch (kind) {
+			case 'byte':
+				if (allowInt && value >= -128 && value < 128) {
+					return { kind: 'byte', value }
+				}
+				break
+			case 'short':
+				if (allowInt && value >= -32768 && value < 32768) {
+					return { kind: 'short', value }
+				}
+				break
+			case 'int':
+				if (allowInt && value >= -2147483648 && value < 2147483648) {
+					return { kind: 'int', value }
+				}
+				break
+			case 'long':
+				if (allowInt && value >= -9223372036854775808n && value < 9223372036854775808n) {
+					return { kind: 'long', value: BigInt(value) }
+				}
+				break
+			case 'float':
+				if (allowFloat) {
+					return { kind: 'float', value }
+				}
+				break
+			case 'double':
+				if (allowFloat) {
+					return { kind: 'double', value }
+				}
+				break
+		}
+		return undefined
+	}
 }
 export interface LiteralType extends McdocBaseType {
 	kind: 'literal'

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -2,7 +2,6 @@ import type { FullResourceLocation } from '@spyglassmc/core'
 import { Arrayable, Dev, max, min, numericEquals } from '@spyglassmc/core'
 import type { EnumKind } from '../node/index.js'
 import { getRangeDelimiter, RangeKind } from '../node/index.js'
-import { numericType } from '../parser/index.js'
 
 export type Attributes = Attribute[]
 export namespace Attributes {

--- a/packages/mcdoc/test/runtime/checker.spec.ts
+++ b/packages/mcdoc/test/runtime/checker.spec.ts
@@ -2,7 +2,11 @@ import * as core from '@spyglassmc/core/lib/index.js'
 import { mockProjectData } from '@spyglassmc/core/test/utils.ts'
 import { localeQuote } from '@spyglassmc/locales'
 import { McdocCheckerContext, typeDefinition } from '@spyglassmc/mcdoc/lib/runtime/checker/index.js'
-import type { McdocType, UnionType } from '@spyglassmc/mcdoc/lib/type/index.js'
+import {
+	LiteralNumericValue,
+	type McdocType,
+	type UnionType,
+} from '@spyglassmc/mcdoc/lib/type/index.js'
 import { describe, it } from 'node:test'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import type { McdocRuntimeError } from '../../lib/runtime/checker/error.js'
@@ -768,20 +772,31 @@ describe('mcdoc runtime checker', () => {
 						reportError: (error) => {
 							errors.push(error)
 						},
-						isEquivalent: (inferred, def) => {
-							switch (inferred.kind) {
-								case 'list':
-									return ['list', 'byte_array', 'int_array', 'long_array', 'tuple']
-										.includes(def.kind)
-								case 'struct':
-									return def.kind === 'struct'
-								case 'double':
-									return ['byte', 'short', 'int', 'long', 'float', 'double'].includes(
-										def.kind,
-									)
-								default:
-									return false
+						tryConvertTo: (node, target) => {
+							if (node instanceof Array) {
+								switch (target.kind) {
+									case 'list':
+										return { kind: 'list', item: { kind: 'any' } }
+									case 'byte_array':
+									case 'int_array':
+									case 'long_array':
+										return { kind: target.kind }
+									case 'tuple':
+										return { kind: 'tuple', items: [] }
+								}
 							}
+							if (typeof node === 'number' || typeof node === 'bigint') {
+								const literalValue = LiteralNumericValue.makeIfValid(
+									target.kind,
+									node,
+									true,
+									true,
+								)
+								if (literalValue !== undefined) {
+									return { kind: 'literal', value: literalValue }
+								}
+							}
+							return undefined
 						},
 					})
 					typeDefinition(

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -105,15 +105,29 @@ export function typeDefinition(
 							items: [],
 						}
 					}
-					if (!options.isPredicate && NbtNumberNode.is(node)) {
-						const literalValue = mcdoc.LiteralNumericValue.makeIfValid(
-							target.kind,
-							node.value,
-							NbtIntegerAlikeNode.is(node),
-							true,
-						)
-						if (literalValue !== undefined) {
-							return { kind: 'literal', value: literalValue }
+					if (!options.isPredicate) {
+						if (NbtNumberNode.is(node)) {
+							const literalValue = mcdoc.LiteralNumericValue.makeIfValid(
+								target.kind,
+								node.value,
+								NbtIntegerAlikeNode.is(node),
+								true,
+							)
+							if (literalValue !== undefined) {
+								return { kind: 'literal', value: literalValue }
+							}
+						}
+						if (NbtCollectionNode.is(node)) {
+							switch (target.kind) {
+								case 'list':
+									return { kind: 'list', item: { kind: 'any' } }
+								case 'byte_array':
+								case 'int_array':
+								case 'long_array':
+									return { kind: target.kind }
+								case 'tuple':
+									return { kind: 'tuple', items: [] }
+							}
 						}
 					}
 					const inferred = inferType(node)

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -9,13 +9,11 @@ import {
 	NbtCompoundNode,
 	NbtIntegerAlikeNode,
 	NbtListNode,
-	NbtLongNode,
 	NbtNode,
 	NbtNumberNode,
 	NbtPathFilterNode,
 	NbtPathIndexNode,
 	NbtPathKeyNode,
-	NbtPrimitiveArrayNode,
 	NbtPrimitiveNode,
 	NbtStringNode,
 } from '../node/index.js'

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -128,10 +128,6 @@ export function typeDefinition(
 							}
 						}
 					}
-					const inferred = inferType(node)
-					if (inferred.kind === target.kind) {
-						return inferred
-					}
 					return undefined
 				},
 				getChildren: node => {
@@ -345,10 +341,6 @@ export function path(
 							case 'tuple':
 								return { kind: 'tuple', items: [] }
 						}
-					}
-					const inferred = inferPath(node)
-					if (inferred.kind === target.kind) {
-						return inferred
 					}
 					return undefined
 				},

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -1,13 +1,21 @@
 import * as core from '@spyglassmc/core'
 import { localeQuote, localize } from '@spyglassmc/locales'
 import * as mcdoc from '@spyglassmc/mcdoc'
+import type { SimplifiedMcdocTypeNoUnion } from '@spyglassmc/mcdoc/lib/runtime/checker/index.js'
 import type { NbtPathChild, NbtPathNode, TypedNbtNode } from '../node/index.js'
 import {
+	NbtByteNode,
+	NbtCollectionNode,
 	NbtCompoundNode,
+	NbtIntegerAlikeNode,
+	NbtListNode,
+	NbtLongNode,
 	NbtNode,
+	NbtNumberNode,
 	NbtPathFilterNode,
 	NbtPathIndexNode,
 	NbtPathKeyNode,
+	NbtPrimitiveArrayNode,
 	NbtPrimitiveNode,
 	NbtStringNode,
 } from '../node/index.js'
@@ -83,31 +91,36 @@ export function typeDefinition(
 			mcdoc.runtime.checker.McdocCheckerContext.create(ctx, {
 				allowMissingKeys: options.isPredicate || options.isMerge,
 				requireCanonical: options.isPredicate,
-				isEquivalent: (inferred, def) => {
-					if (def.kind === 'boolean') {
-						// TODO: this should check whether the value is 0 or 1
-						return inferred.kind === 'byte'
+				tryConvertTo: (node, target) => {
+					if (target.kind === 'boolean' && NbtByteNode.is(node)) {
+						if (node.value === 0) {
+							return { kind: 'literal', value: { kind: 'boolean', value: false } }
+						} else if (node.value === 1) {
+							return { kind: 'literal', value: { kind: 'boolean', value: true } }
+						}
 					}
-					if (inferred.kind === 'list') {
-						return def.kind === 'list' || def.kind === 'tuple'
+					if (target.kind === 'tuple' && NbtListNode.is(node)) {
+						return {
+							kind: 'tuple',
+							items: [],
+						}
 					}
-					if (options.isPredicate) {
-						return inferred.kind === def.kind
+					if (!options.isPredicate && NbtNumberNode.is(node)) {
+						const literalValue = mcdoc.LiteralNumericValue.makeIfValid(
+							target.kind,
+							node.value,
+							NbtIntegerAlikeNode.is(node),
+							true,
+						)
+						if (literalValue !== undefined) {
+							return { kind: 'literal', value: literalValue }
+						}
 					}
-					switch (inferred.kind) {
-						case 'struct':
-							return def.kind === 'struct'
-						case 'byte':
-						case 'short':
-						case 'int':
-						case 'long':
-							return ['byte', 'short', 'int', 'long', 'float', 'double'].includes(def.kind)
-						case 'float':
-						case 'double':
-							return ['float', 'double'].includes(def.kind)
-						default:
-							return false
+					const inferred = inferType(node)
+					if (inferred.kind === target.kind) {
+						return inferred
 					}
+					return undefined
 				},
 				getChildren: node => {
 					const { type } = node
@@ -186,7 +199,7 @@ export function typeDefinition(
 	}
 }
 
-function inferType(node: NbtNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
+function inferType(node: NbtNode): SimplifiedMcdocTypeNoUnion {
 	switch (node.type) {
 		case 'nbt:byte':
 			return { kind: 'literal', value: { kind: 'byte', value: node.value } }
@@ -308,18 +321,24 @@ export function path(
 			mcdoc.runtime.checker.McdocCheckerContext.create(ctx, {
 				allowMissingKeys: true,
 				requireCanonical: true,
-				isEquivalent: (inferred, def) => {
-					switch (inferred.kind) {
-						case 'list':
-						case 'byte_array':
-						case 'int_array':
-						case 'long_array':
-							return ['list', 'tuple', 'byte_array', 'int_array', 'long_array'].includes(
-								def.kind,
-							)
-						default:
-							return false
+				tryConvertTo: (node, target) => {
+					if (NbtPathIndexNode.is(node.node)) {
+						switch (target.kind) {
+							case 'list':
+								return { kind: 'list', item: { kind: 'any' } }
+							case 'byte_array':
+							case 'int_array':
+							case 'long_array':
+								return { kind: target.kind }
+							case 'tuple':
+								return { kind: 'tuple', items: [] }
+						}
 					}
+					const inferred = inferPath(node)
+					if (inferred.kind === target.kind) {
+						return inferred
+					}
+					return undefined
 				},
 				getChildren: (link): mcdoc.runtime.checker.RuntimeUnion<NbtPathLink>[] => {
 					while (link.next && link.node.type !== 'leaf' && NbtPathFilterNode.is(link.node)) {
@@ -396,7 +415,7 @@ export function path(
 	}
 }
 
-function inferPath(link: NbtPathLink): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
+function inferPath(link: NbtPathLink): SimplifiedMcdocTypeNoUnion {
 	if (link.node.type === 'leaf') {
 		return { kind: 'unsafe' }
 	}


### PR DESCRIPTION
This allows to convert a runtime type to a requested definition type.

Fixes #1991
Fixes #2022

Also modified the /nbt package to allow conversion between list types (when we are in non-canonical cases), working towards #1471 (effectively fixing the #1500 / #1812 / #1995 part of it)