### PR TITLE
Correctly use `@` in mcdoc array examples instead of `#`

### DIFF
--- a/docs/user/mcdoc/specification.adoc
+++ b/docs/user/mcdoc/specification.adoc
@@ -609,9 +609,9 @@ The first optional range defines the range the value must be in, while the secon
 [source,rust]
 ----
 byte[]              // A collection of bytes.
-byte#0..1[]         // A collection of bytes 0 or 1.
-int[] # 4           // A collection of 4 integers.
-long#0..[] # 3..    // A collection of 3 or more non-negative longs.
+byte@0..1[]         // A collection of bytes 0 or 1.
+int[] @ 4           // A collection of 4 integers.
+long@0..[] @ 3..    // A collection of 3 or more non-negative longs.
 ----
 ====
 


### PR DESCRIPTION
*"Example 18. Primitive array types"* in the [mcdoc spec](https://spyglassmc.com/user/mcdoc/specification.html#primitive-array-type) currently writes arrays like this: `long#0..[] # 3..`, but as per the syntax rules above it, `@` should be used instead of `#`.
I have also confirmed in the source code that the `primitiveArrayType` parser references `atIntRange`