### PR TITLE
✨ Fetcher improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"globals": "^17.6.0",
 				"ts-loader": "^9.4.2",
 				"typescript": "^6.0.3",
+				"undici": "^7.25.0",
 				"webpack": "^5.95.0",
 				"webpack-cli": "^5.0.2",
 				"wireit": "^0.9.5"
@@ -11809,9 +11810,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -14972,9 +14973,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"globals": "^17.6.0",
 		"ts-loader": "^9.4.2",
 		"typescript": "^6.0.3",
+		"undici": "^7.25.0",
 		"webpack": "^5.95.0",
 		"webpack-cli": "^5.0.2",
 		"wireit": "^0.9.5"

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -11,7 +11,7 @@ import { pipeline } from 'node:stream/promises'
 import type streamWeb from 'node:stream/web'
 import url from 'node:url'
 import { promisify } from 'node:util'
-import type { DecompressedFile, RootUriString } from '../../index.js'
+import { isObject, type DecompressedFile, type RootUriString } from '../../index.js'
 import { Logger } from '../Logger.js'
 import type { Uri } from '../util.js'
 import type { Externals, FsLocation } from './index.js'
@@ -136,20 +136,20 @@ interface CacheIndex {
 }
 namespace CacheIndex {
 	export function assert(val: unknown): asserts val is CacheIndex {
-		if (!(!!val && typeof val === 'object')) {
+		if (!isObject(val)) {
 			throw new Error('Expected an object')
 		}
-		if (!('index' in val && !!val.index && typeof val.index === 'object')) {
+		if (!('index' in val && isObject(val.index))) {
 			throw new Error("Expected 'index' to exist as an object")
 		}
 		if (
 			!(Object.values(val.index).every((i) =>
-				!!i && typeof i === 'object'
+				isObject(i)
 				&& Object.values(i).every((v) =>
-					!!v && typeof v === 'object'
+					isObject(v)
 					&& 'status' in v && typeof v.status === 'number'
 					&& 'statusText' in v && typeof v.statusText === 'string'
-					&& 'headers' in v && !!v.headers && typeof v.headers === 'object'
+					&& 'headers' in v && isObject(v.headers)
 					&& Object.values(v.headers).every((s) => typeof s === 'string')
 					&& 'sha1' in v && typeof v.sha1 === 'string' && /^[0-9a-f]{40}$/.test(v.sha1)
 					&& 'cacheTime' in v && typeof v.cacheTime === 'number'

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -2,7 +2,7 @@ import decompress from 'decompress'
 import { Buffer } from 'node:buffer'
 import cp from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
-import fs from 'node:fs'
+import type fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import os from 'node:os'
 import process from 'node:process'
@@ -93,7 +93,7 @@ export function getNodeJsExternals(
 			},
 			web: {
 				getCache: async () => {
-					return new HttpCache(cacheRoot, logger)
+					return new HttpCache(cacheRoot, logger, nodeFsp)
 				},
 			},
 		} satisfies Externals,
@@ -167,20 +167,25 @@ namespace CacheIndex {
  */
 class HttpCache implements Cache {
 	readonly #cacheRoot: RootUriString | undefined
+	readonly #httpRoot: RootUriString | undefined
 	readonly #indexUri: string | undefined
 	readonly #objectsRoot: RootUriString | undefined
 	readonly #tempRoot: RootUriString | undefined
 	readonly #logger: Logger
+	readonly #fsp: typeof fsp
 	#index: CacheIndex | undefined
+	#loadIndexPromise: Promise<void> | undefined
 
-	constructor(cacheRoot: RootUriString | undefined, logger: Logger) {
+	constructor(cacheRoot: RootUriString | undefined, logger: Logger, nodeFsp: typeof fsp) {
 		if (cacheRoot) {
-			this.#cacheRoot = `${cacheRoot}http/`
-			this.#indexUri = `${this.#cacheRoot}index.json`
-			this.#objectsRoot = `${this.#cacheRoot}objects/`
-			this.#tempRoot = `${this.#cacheRoot}temp/`
+			this.#cacheRoot = cacheRoot
+			this.#httpRoot = `${this.#cacheRoot}http/`
+			this.#indexUri = `${this.#httpRoot}index.json`
+			this.#objectsRoot = `${this.#httpRoot}objects/`
+			this.#tempRoot = `${this.#httpRoot}temp/`
 		}
 		this.#logger = logger
+		this.#fsp = nodeFsp
 	}
 
 	async match(
@@ -200,7 +205,7 @@ class HttpCache implements Cache {
 		}
 
 		try {
-			const objectFileHandle = await fsp.open(
+			const objectFileHandle = await this.#fsp.open(
 				this.#getObjectUri(this.#objectsRoot, indexEntry.sha1),
 			)
 			const bodyStream = objectFileHandle.createReadStream({ autoClose: true })
@@ -214,6 +219,7 @@ class HttpCache implements Cache {
 			)
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException)?.code === 'ENOENT') {
+				this.#logger.warn(`Object file for ${JSON.stringify(indexEntry)} does not exist`, e)
 				delete index.index[requestUri]?.[requestRange ?? '']
 				if (Object.values(index.index[requestUri]!).length === 0) {
 					delete index.index[requestUri]
@@ -274,45 +280,49 @@ class HttpCache implements Cache {
 
 		// Tee the body stream to both a temporary file write stream and the SHA-1 hash stream
 		const tempUri = new URL(`body.${randomUUID()}.tmp`, tempRoot)
-		await fsp.mkdir(new URL(tempRoot), { recursive: true })
-		const writeStream = fs.createWriteStream(tempUri, { autoClose: true })
+		await this.#fsp.mkdir(new URL(tempRoot), { recursive: true, mode: 0o755 })
+		const tempHandle = await this.#fsp.open(tempUri, 'w', 0o644)
+		const writeStream = tempHandle.createWriteStream({ autoClose: true })
 		bodyStream.pipe(bodyHash)
 		await pipeline(bodyStream, writeStream)
 
 		// Move the temporary file to the SHA-1 Content-addressable objects store
 		const bodySha1 = bodyHash.digest('hex')
 		const objectUri = this.#getObjectUri(objectsRoot, bodySha1)
-		await fsp.mkdir(new URL('.', objectUri), { recursive: true })
-		await fsp.rename(tempUri, objectUri)
+		await this.#fsp.mkdir(new URL('.', objectUri), { recursive: true, mode: 0o755 })
+		await this.#fsp.rename(tempUri, objectUri)
 
 		return bodySha1
 	}
 
 	async #loadIndex(indexUri: string): Promise<CacheIndex> {
-		if (!this.#index) {
+		await (this.#loadIndexPromise ??= (async () => {
 			try {
-				const parsedIndex = JSON.parse(await fsp.readFile(new URL(indexUri), 'utf8'))
+				const parsedIndex = JSON.parse(await this.#fsp.readFile(new URL(indexUri), 'utf8'))
 				CacheIndex.assert(parsedIndex)
 				this.#index = parsedIndex
 			} catch (e) {
 				if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
 					// Triger legacy cache clean up if no index file for the new cache scheme exists.
+					this.#logger.info('[HttpCache] No cache index found; cleaning up legacy cache files')
 					await this.#cleanUpLegacyCache()
 				} else {
 					this.#logger.warn('[HttpCache] Corrupted cache index', e)
 				}
 				this.#index = { index: {} }
 			}
-		}
-		return this.#index
+		})())
+		return this.#index!
 	}
 
 	async #saveIndex(indexUri: string, tempRoot: RootUriString): Promise<void> {
 		try {
 			const tempUri = new URL(`index.${randomUUID()}.tmp`, tempRoot)
-			await fsp.mkdir(new URL(tempRoot), { recursive: true })
-			await fsp.writeFile(tempUri, `${JSON.stringify(this.#index)}${os.EOL}`)
-			await fsp.rename(tempUri, new URL(indexUri))
+			await this.#fsp.mkdir(new URL(tempRoot), { recursive: true, mode: 0o755 })
+			await this.#fsp.writeFile(tempUri, `${JSON.stringify(this.#index)}${os.EOL}`, {
+				mode: 0o644,
+			})
+			await this.#fsp.rename(tempUri, new URL(indexUri))
 		} catch (e) {
 			this.#logger.warn('[HttpCache] Failed saving index', e)
 		}
@@ -325,12 +335,12 @@ class HttpCache implements Cache {
 	 */
 	async #cleanUpLegacyCache(): Promise<void> {
 		// Stupid hardcoded path check to make sure we don't accidentally delete some random files somehow
-		if (!(this.#cacheRoot && this.#cacheRoot.endsWith('/spyglassmc-nodejs/'))) {
+		if (!(this.#cacheRoot && this.#cacheRoot.endsWith('/spyglassmc-nodejs/') && this.#httpRoot)) {
 			return
 		}
 
 		try {
-			await fsp.rm(new URL('downloader/', this.#cacheRoot), { recursive: true })
+			await this.#fsp.rm(new URL('downloader/', this.#cacheRoot), { recursive: true })
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
 				this.#logger.warn('[HttpCache] Failed cleaning up downloader/ dir', e)
@@ -338,11 +348,10 @@ class HttpCache implements Cache {
 		}
 
 		try {
-			const httpRootUri = new URL('http/', this.#cacheRoot)
-			const httpDir = await fsp.opendir(httpRootUri)
+			const httpDir = await this.#fsp.opendir(new URL(this.#httpRoot))
 			for await (const entry of httpDir) {
 				if (entry.isFile() && (entry.name.endsWith('.bin') || entry.name.endsWith('.etag'))) {
-					await fsp.rm(new URL(entry.name, httpRootUri))
+					await this.#fsp.rm(new URL(entry.name, this.#httpRoot))
 				}
 			}
 		} catch (e) {
@@ -370,7 +379,7 @@ class HttpCache implements Cache {
 		}
 
 		try {
-			await fsp.rm(this.#getObjectUri(objectsRoot, sha1))
+			await this.#fsp.rm(this.#getObjectUri(objectsRoot, sha1))
 			return true
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -136,8 +136,10 @@ class HttpCache implements Cache {
 
 		const fileName = this.#getFileName(request)
 		try {
-			const etag = (await fsp.readFile(new URL(`${fileName}.etag`, this.#cacheRoot), 'utf8'))
-				.trim()
+			const headers = JSON.parse(
+				(await fsp.readFile(new URL(`${fileName}.headers`, this.#cacheRoot), 'utf8'))
+					.trim(),
+			)
 			const bodyStream = fs.createReadStream(new URL(`${fileName}.bin`, this.#cacheRoot))
 			return new Response(
 				stream.Readable.toWeb(bodyStream) as ReadableStream,
@@ -145,7 +147,7 @@ class HttpCache implements Cache {
 				// stream Readable -> stream/web ReadableStream
 				//                                \_______________/
 				//                 stream/web ReadableStream -> DOM ReadableStream
-				{ headers: { etag } },
+				{ headers },
 			)
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException)?.code === 'ENOENT') {
@@ -158,7 +160,8 @@ class HttpCache implements Cache {
 
 	async put(request: RequestInfo | URL, response: Response): Promise<void> {
 		const etag = response.headers.get('etag')
-		if (!(this.#cacheRoot && response.body && etag)) {
+		const lastModified = response.headers.get('last-modified')
+		if (!(this.#cacheRoot && response.body && (etag || lastModified))) {
 			return
 		}
 
@@ -172,7 +175,10 @@ class HttpCache implements Cache {
 				//                 |       DOM ReadableStream -> stream/web ReadableStream
 				// stream/web ReadableStream -> stream Readable
 			),
-			fsp.writeFile(new URL(`${fileName}.etag`, this.#cacheRoot), `${etag}${os.EOL}`),
+			fsp.writeFile(
+				new URL(`${fileName}.headers`, this.#cacheRoot),
+				`${JSON.stringify({ etag, 'last-modified': lastModified })}${os.EOL}`,
+			),
 		])
 	}
 

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -1,19 +1,27 @@
 import decompress from 'decompress'
 import { Buffer } from 'node:buffer'
 import cp from 'node:child_process'
-import fs, { promises as fsp } from 'node:fs'
+import { createHash, randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
 import os from 'node:os'
 import process from 'node:process'
 import stream from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import type streamWeb from 'node:stream/web'
 import url from 'node:url'
 import { promisify } from 'node:util'
 import type { DecompressedFile, RootUriString } from '../../index.js'
+import { Logger } from '../Logger.js'
 import type { Uri } from '../util.js'
 import type { Externals, FsLocation } from './index.js'
 
 export function getNodeJsExternals(
-	{ cacheRoot, nodeFsp = fsp }: { cacheRoot?: RootUriString; nodeFsp?: typeof fsp } = {},
+	{ cacheRoot, logger = Logger.create(), nodeFsp = fsp }: {
+		cacheRoot?: RootUriString
+		logger?: Logger
+		nodeFsp?: typeof fsp
+	} = {},
 ) {
 	return Object.freeze(
 		{
@@ -85,7 +93,7 @@ export function getNodeJsExternals(
 			},
 			web: {
 				getCache: async () => {
-					return new HttpCache(cacheRoot)
+					return new HttpCache(cacheRoot, logger)
 				},
 			},
 		} satisfies Externals,
@@ -113,44 +121,105 @@ function toPath(path: FsLocation): string {
 
 const uriToPath = (uri: string | Uri) => url.fileURLToPath(uri)
 
+interface CacheIndex {
+	index: {
+		[uri: string]: {
+			[range: string]: {
+				status: number
+				statusText: string
+				headers: Record<string, string>
+				sha1: string
+				cacheTime: number
+			} | undefined
+		} | undefined
+	}
+}
+namespace CacheIndex {
+	export function assert(val: unknown): asserts val is CacheIndex {
+		if (!(!!val && typeof val === 'object')) {
+			throw new Error('Expected an object')
+		}
+		if (!('index' in val && !!val.index && typeof val.index === 'object')) {
+			throw new Error("Expected 'index' to exist as an object")
+		}
+		if (
+			!(Object.values(val.index).every((i) =>
+				!!i && typeof i === 'object'
+				&& Object.values(i).every((v) =>
+					!!v && typeof v === 'object'
+					&& 'status' in v && typeof v.status === 'number'
+					&& 'statusText' in v && typeof v.statusText === 'string'
+					&& 'headers' in v && !!v.headers && typeof v.headers === 'object'
+					&& Object.values(v.headers).every((s) => typeof s === 'string')
+					&& 'sha1' in v && typeof v.sha1 === 'string' && /^[0-9a-f]{40}$/.test(v.sha1)
+					&& 'cacheTime' in v && typeof v.cacheTime === 'number'
+				)
+			))
+		) {
+			throw new Error('Malformed index structure')
+		}
+	}
+}
+
 /**
  * A non-spec-compliant, non-complete implementation of the Cache Web API for use in Spyglass.
  * This class stores the cached response on the file system under the cache root.
  */
 class HttpCache implements Cache {
 	readonly #cacheRoot: RootUriString | undefined
+	readonly #indexUri: string | undefined
+	readonly #objectsRoot: RootUriString | undefined
+	readonly #tempRoot: RootUriString | undefined
+	readonly #logger: Logger
+	#index: CacheIndex | undefined
 
-	constructor(cacheRoot: RootUriString | undefined) {
+	constructor(cacheRoot: RootUriString | undefined, logger: Logger) {
 		if (cacheRoot) {
 			this.#cacheRoot = `${cacheRoot}http/`
+			this.#indexUri = `${this.#cacheRoot}index.json`
+			this.#objectsRoot = `${this.#cacheRoot}objects/`
+			this.#tempRoot = `${this.#cacheRoot}temp/`
 		}
+		this.#logger = logger
 	}
 
 	async match(
 		request: RequestInfo | URL,
 		_options?: CacheQueryOptions | undefined,
 	): Promise<Response | undefined> {
-		if (!this.#cacheRoot) {
+		if (!(this.#indexUri && this.#objectsRoot && this.#tempRoot)) {
 			return undefined
 		}
 
-		const fileName = this.#getFileName(request)
+		const index = await this.#loadIndex(this.#indexUri)
+		const requestUri = request instanceof Request ? request.url : request.toString()
+		const requestRange = request instanceof Request ? request.headers.get('range') : undefined
+		const indexEntry = index.index[requestUri]?.[requestRange ?? '']
+		if (!indexEntry) {
+			return undefined
+		}
+
 		try {
-			const headers = JSON.parse(
-				(await fsp.readFile(new URL(`${fileName}.headers`, this.#cacheRoot), 'utf8'))
-					.trim(),
+			const objectFileHandle = await fsp.open(
+				this.#getObjectUri(this.#objectsRoot, indexEntry.sha1),
 			)
-			const bodyStream = fs.createReadStream(new URL(`${fileName}.bin`, this.#cacheRoot))
+			const bodyStream = objectFileHandle.createReadStream({ autoClose: true })
 			return new Response(
 				stream.Readable.toWeb(bodyStream) as ReadableStream,
-				//              \___/
-				// stream Readable -> stream/web ReadableStream
-				//                                \_______________/
-				//                 stream/web ReadableStream -> DOM ReadableStream
-				{ headers },
+				{
+					headers: indexEntry.headers,
+					status: indexEntry.status,
+					statusText: indexEntry.statusText,
+				},
 			)
 		} catch (e) {
 			if ((e as NodeJS.ErrnoException)?.code === 'ENOENT') {
+				delete index.index[requestUri]?.[requestRange ?? '']
+				if (Object.values(index.index[requestUri]!).length === 0) {
+					delete index.index[requestUri]
+				}
+				await this.#saveIndex(this.#indexUri, this.#tempRoot)
+
 				return undefined
 			}
 
@@ -159,32 +228,161 @@ class HttpCache implements Cache {
 	}
 
 	async put(request: RequestInfo | URL, response: Response): Promise<void> {
-		const etag = response.headers.get('etag')
-		const lastModified = response.headers.get('last-modified')
-		if (!(this.#cacheRoot && response.body && (etag || lastModified))) {
+		if (!(this.#tempRoot && this.#objectsRoot && this.#indexUri && response.body)) {
 			return
 		}
 
-		const fileName = this.#getFileName(request)
-		await fsp.mkdir(new URL(this.#cacheRoot), { recursive: true })
-		await Promise.all([
-			fsp.writeFile(
-				new URL(`${fileName}.bin`, this.#cacheRoot),
-				stream.Readable.fromWeb(response.body as streamWeb.ReadableStream),
-				//              \_____/               \_________________________/
-				//                 |       DOM ReadableStream -> stream/web ReadableStream
-				// stream/web ReadableStream -> stream Readable
-			),
-			fsp.writeFile(
-				new URL(`${fileName}.headers`, this.#cacheRoot),
-				`${JSON.stringify({ etag, 'last-modified': lastModified })}${os.EOL}`,
-			),
-		])
+		const etag = response.headers.get('etag')
+		const lastModified = response.headers.get('last-modified')
+		if (!(etag || lastModified)) {
+			return
+		}
+
+		const requestUri = request instanceof Request ? request.url : request.toString()
+		const requestRange = request instanceof Request ? request.headers.get('range') : undefined
+
+		const bodySha1 = await this.#saveResponseBody(
+			response.body as streamWeb.ReadableStream,
+			this.#tempRoot,
+			this.#objectsRoot,
+		)
+
+		const index = await this.#loadIndex(this.#indexUri)
+		index.index[requestUri] ??= Object.create(null)
+		const previousEntry = index.index[requestUri]![requestRange ?? '']
+		index.index[requestUri]![requestRange ?? ''] = {
+			status: response.status,
+			statusText: response.statusText,
+			headers: Object.fromEntries(response.headers),
+			sha1: bodySha1,
+			cacheTime: Date.now(),
+		}
+		await this.#saveIndex(this.#indexUri, this.#tempRoot)
+
+		if (previousEntry) {
+			await this.#cleanUpDanglingObject(this.#objectsRoot, index, previousEntry.sha1)
+		}
 	}
 
-	#getFileName(request: RequestInfo | URL) {
-		const uriString = request instanceof Request ? request.url : request.toString()
-		return Buffer.from(uriString, 'utf8').toString('base64url')
+	async #saveResponseBody(
+		body: streamWeb.ReadableStream,
+		tempRoot: RootUriString,
+		objectsRoot: RootUriString,
+	) {
+		const bodyStream = stream.Readable.fromWeb(body)
+		const bodyHash = createHash('sha1')
+
+		// Tee the body stream to both a temporary file write stream and the SHA-1 hash stream
+		const tempUri = new URL(`body.${randomUUID()}.tmp`, tempRoot)
+		await fsp.mkdir(new URL(tempRoot), { recursive: true })
+		const writeStream = fs.createWriteStream(tempUri, { autoClose: true })
+		bodyStream.pipe(bodyHash)
+		await pipeline(bodyStream, writeStream)
+
+		// Move the temporary file to the SHA-1 Content-addressable objects store
+		const bodySha1 = bodyHash.digest('hex')
+		const objectUri = this.#getObjectUri(objectsRoot, bodySha1)
+		await fsp.mkdir(new URL('.', objectUri), { recursive: true })
+		await fsp.rename(tempUri, objectUri)
+
+		return bodySha1
+	}
+
+	async #loadIndex(indexUri: string): Promise<CacheIndex> {
+		if (!this.#index) {
+			try {
+				const parsedIndex = JSON.parse(await fsp.readFile(new URL(indexUri), 'utf8'))
+				CacheIndex.assert(parsedIndex)
+				this.#index = parsedIndex
+			} catch (e) {
+				if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+					// Triger legacy cache clean up if no index file for the new cache scheme exists.
+					await this.#cleanUpLegacyCache()
+				} else {
+					this.#logger.warn('[HttpCache] Corrupted cache index', e)
+				}
+				this.#index = { index: {} }
+			}
+		}
+		return this.#index
+	}
+
+	async #saveIndex(indexUri: string, tempRoot: RootUriString): Promise<void> {
+		try {
+			const tempUri = new URL(`index.${randomUUID()}.tmp`, tempRoot)
+			await fsp.mkdir(new URL(tempRoot), { recursive: true })
+			await fsp.writeFile(tempUri, `${JSON.stringify(this.#index)}${os.EOL}`)
+			await fsp.rename(tempUri, new URL(indexUri))
+		} catch (e) {
+			this.#logger.warn('[HttpCache] Failed saving index', e)
+		}
+	}
+
+	/**
+	 * Remove cache files used by older versions of Spyglass.
+	 * - until v2026.5.8+8c7f6e, `${cacheRoot}downloader/`
+	 * - until v2026.5.16+9c4fa2, `${cacheRoot}http/${base64UrlEncoded}.${'bin' | 'etag'}`
+	 */
+	async #cleanUpLegacyCache(): Promise<void> {
+		// Stupid hardcoded path check to make sure we don't accidentally delete some random files somehow
+		if (!(this.#cacheRoot && this.#cacheRoot.endsWith('/spyglassmc-nodejs/'))) {
+			return
+		}
+
+		try {
+			await fsp.rm(new URL('downloader/', this.#cacheRoot), { recursive: true })
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+				this.#logger.warn('[HttpCache] Failed cleaning up downloader/ dir', e)
+			}
+		}
+
+		try {
+			const httpRootUri = new URL('http/', this.#cacheRoot)
+			const httpDir = await fsp.opendir(httpRootUri)
+			for await (const entry of httpDir) {
+				if (entry.isFile() && (entry.name.endsWith('.bin') || entry.name.endsWith('.etag'))) {
+					await fsp.rm(new URL(entry.name, httpRootUri))
+				}
+			}
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+				this.#logger.warn('[HttpCache] Failed cleaning up legacy cache files', e)
+			}
+		}
+	}
+
+	async #cleanUpDanglingObject(
+		objectsRoot: RootUriString,
+		index: CacheIndex,
+		sha1: string,
+	): Promise<boolean> {
+		if (
+			Object.values(index.index).some(
+				(i) =>
+					Object.values(i!).some(
+						(v) => v!.sha1 === sha1,
+					),
+			)
+		) {
+			// The object is still referenced
+			return false
+		}
+
+		try {
+			await fsp.rm(this.#getObjectUri(objectsRoot, sha1))
+			return true
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+				this.#logger.warn('[HttpCache] Failed cleaning up dangling object', e)
+			}
+		}
+
+		return false
+	}
+
+	#getObjectUri(objectsRoot: RootUriString, sha1: string) {
+		return new URL(`${sha1.slice(0, 2)}/${sha1}`, objectsRoot)
 	}
 
 	async add(): Promise<void> {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -335,11 +335,10 @@ class HttpCache implements Cache {
 	 * - until v2026.5.16+9c4fa2, `${cacheRoot}http/${base64UrlEncoded}.${'bin' | 'etag'}`
 	 */
 	async #cleanUpLegacyCache(): Promise<void> {
-		// Stupid hardcoded path check to make sure we don't accidentally delete some random files somehow
-		if (!(this.#cacheRoot && this.#cacheRoot.endsWith('/spyglassmc-nodejs/') && this.#httpRoot)) {
+		if (!this.#httpRoot) {
 			return
 		}
-
+		
 		try {
 			await this.#fsp.rm(new URL('downloader/', this.#cacheRoot), { recursive: true })
 		} catch (e) {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -247,14 +247,15 @@ class HttpCache implements Cache {
 		const requestUri = request instanceof Request ? request.url : request.toString()
 		const requestRange = request instanceof Request ? request.headers.get('range') : undefined
 
-		const bodySha1 = await this.#saveResponseBody(
+		// Save response body in a temp file and computes its SHA-1 digest
+		const { bodySha1, bodyTempUri } = await this.#saveResponseBody(
 			response.body as streamWeb.ReadableStream,
 			this.#tempRoot,
-			this.#objectsRoot,
 		)
 
+		// Update the index
 		const index = await this.#loadIndex(this.#indexUri)
-		index.index[requestUri] ??= Object.create(null)
+		index.index[requestUri] ??= {}
 		const previousEntry = index.index[requestUri]![requestRange ?? '']
 		index.index[requestUri]![requestRange ?? ''] = {
 			status: response.status,
@@ -268,13 +269,18 @@ class HttpCache implements Cache {
 		if (previousEntry) {
 			await this.#cleanUpDanglingObject(this.#objectsRoot, index, previousEntry.sha1)
 		}
+
+		// Rename the temp body file to its final location in the content-addressable object store
+		// match() would gracefully handle missing object if this step fails for any reason
+		const objectUri = this.#getObjectUri(this.#objectsRoot, bodySha1)
+		await this.#fsp.mkdir(new URL('.', objectUri), { recursive: true, mode: 0o755 })
+		await this.#fsp.rename(bodyTempUri, objectUri)
 	}
 
 	async #saveResponseBody(
 		body: streamWeb.ReadableStream,
 		tempRoot: RootUriString,
-		objectsRoot: RootUriString,
-	) {
+	): Promise<{ bodySha1: string; bodyTempUri: URL }> {
 		const bodyStream = stream.Readable.fromWeb(body)
 		const bodyHash = createHash('sha1')
 
@@ -286,13 +292,9 @@ class HttpCache implements Cache {
 		bodyStream.pipe(bodyHash)
 		await pipeline(bodyStream, writeStream)
 
-		// Move the temporary file to the SHA-1 Content-addressable objects store
 		const bodySha1 = bodyHash.digest('hex')
-		const objectUri = this.#getObjectUri(objectsRoot, bodySha1)
-		await this.#fsp.mkdir(new URL('.', objectUri), { recursive: true, mode: 0o755 })
-		await this.#fsp.rename(tempUri, objectUri)
 
-		return bodySha1
+		return { bodySha1, bodyTempUri: tempUri }
 	}
 
 	async #loadIndex(indexUri: string): Promise<CacheIndex> {
@@ -338,7 +340,7 @@ class HttpCache implements Cache {
 		if (!this.#httpRoot) {
 			return
 		}
-		
+
 		try {
 			await this.#fsp.rm(new URL('downloader/', this.#cacheRoot), { recursive: true })
 		} catch (e) {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -11,7 +11,7 @@ import { pipeline } from 'node:stream/promises'
 import type streamWeb from 'node:stream/web'
 import url from 'node:url'
 import { promisify } from 'node:util'
-import { isObject, type DecompressedFile, type RootUriString } from '../../index.js'
+import { type DecompressedFile, Dev, isObject, type RootUriString } from '../../index.js'
 import { Logger } from '../Logger.js'
 import type { Uri } from '../util.js'
 import type { Externals, FsLocation } from './index.js'
@@ -317,6 +317,7 @@ class HttpCache implements Cache {
 
 	async #saveIndex(indexUri: string, tempRoot: RootUriString): Promise<void> {
 		try {
+			Dev.assertDefined(this.#index)
 			const tempUri = new URL(`index.${randomUUID()}.tmp`, tempRoot)
 			await this.#fsp.mkdir(new URL(tempRoot), { recursive: true, mode: 0o755 })
 			await this.#fsp.writeFile(tempUri, `${JSON.stringify(this.#index)}${os.EOL}`, {

--- a/packages/core/src/common/util.ts
+++ b/packages/core/src/common/util.ts
@@ -395,6 +395,10 @@ export function streamToBytes(
 	return new Response(stream).bytes()
 }
 
+export function sleep(delayMs: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, delayMs))
+}
+
 /**
  * Return a read-write TARGET type if the INPUT type is read-write, and a
  * readonly TARGET type if the INPUT type is readonly, and `never` if the INPUT

--- a/packages/core/src/service/fetcher.ts
+++ b/packages/core/src/service/fetcher.ts
@@ -17,11 +17,14 @@ export async function fetchWithCache(
 	const cache = await web.getCache()
 	const request = new Request(input, init)
 	const cachedResponse = await cache.match(request)
-	const cachedEtag = cachedResponse?.headers.get('ETag')
+	const cachedEtag = cachedResponse?.headers.get('etag')
+	const cachedLastModified = cachedResponse?.headers.get('last-modified')
 	if (cachedEtag) {
-		request.headers.set('If-None-Match', cachedEtag)
+		request.headers.set('if-none-match', cachedEtag)
+	} else if (cachedLastModified) {
+		request.headers.set('if-modified-since', cachedLastModified)
 	}
-	request.headers.set('User-Agent', 'SpyglassMC (+https://spyglassmc.com)')
+	request.headers.set('user-agent', 'SpyglassMC (+https://spyglassmc.com)')
 	try {
 		const response = await fetchWithRetries(request)
 		if (response.status === 304) {
@@ -31,7 +34,7 @@ export async function fetchWithCache(
 		} else if (!response.ok) {
 			let message = response.statusText
 			try {
-				message = (await response.json()).message
+				message = await response.text()
 			} catch {}
 			throw new TypeError(`${response.status} ${message}`)
 		} else {

--- a/packages/core/src/service/fetcher.ts
+++ b/packages/core/src/service/fetcher.ts
@@ -1,7 +1,12 @@
-import { Dev } from '../common/index.js'
+import { Dev, sleep } from '../common/index.js'
 import type { Externals, Logger } from '../common/index.js'
 
-const FETCH_TIMEOUT_MS = 30_000
+const FETCH_RETRY_BASE_MS = 1_000
+const FETCH_RETRY_MAX_ATTEMPTS = 3
+const FETCH_PER_TRY_TIMEOUT_MS = 10_000
+const FETCH_TOTAL_TIMEOUT_MS = 15_000
+
+const STALE_HEADER = 'spyglassmc-is-stale'
 
 export async function fetchWithCache(
 	{ web }: Externals,
@@ -18,7 +23,7 @@ export async function fetchWithCache(
 	}
 	request.headers.set('User-Agent', 'SpyglassMC (+https://spyglassmc.com)')
 	try {
-		const response = await fetch(request, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+		const response = await fetchWithRetries(request)
 		if (response.status === 304) {
 			Dev.assertDefined(cachedResponse)
 			logger.info(`[fetchWithCache] reusing cache for ${request.url}`)
@@ -42,10 +47,52 @@ export async function fetchWithCache(
 		logger.warn('[fetchWithCache] fetch', e)
 		if (cachedResponse) {
 			logger.info(`[fetchWithCache] falling back to cache for ${request.url}`)
-			return cachedResponse
+			// Set the stale header when fallback is used
+			const newHeaders = new Headers(cachedResponse.headers)
+			newHeaders.set(STALE_HEADER, '1')
+			return new Response(cachedResponse.body, {
+				status: cachedResponse.status,
+				statusText: cachedResponse.statusText,
+				headers: newHeaders,
+			})
 		}
 		throw e
 	}
+}
+
+export function isStaleFetcherResponse(response: Response) {
+	return response.headers.has(STALE_HEADER)
+}
+
+async function fetchWithRetries(request: Request) {
+	let lastResult: Response | Error | undefined
+	const totalSignal = AbortSignal.timeout(FETCH_TOTAL_TIMEOUT_MS)
+
+	Dev.assertTrue(FETCH_RETRY_MAX_ATTEMPTS > 0, 'Number of attempts must be greater than 0')
+	for (let i = 0; i < FETCH_RETRY_MAX_ATTEMPTS; i++) {
+		const isLastAttempt = i === FETCH_RETRY_MAX_ATTEMPTS - 1
+		try {
+			lastResult = await fetch(request.clone(), {
+				signal: AbortSignal.any([
+					totalSignal,
+					AbortSignal.timeout(FETCH_PER_TRY_TIMEOUT_MS),
+				]),
+			})
+			if (lastResult.status < 500) {
+				return lastResult
+			}
+		} catch (e) {
+			lastResult = e as Error
+		}
+		if (!isLastAttempt) {
+			await sleep(Math.round(Math.random() * (2 ** i) * FETCH_RETRY_BASE_MS))
+		}
+	}
+
+	if (lastResult instanceof Response) {
+		return lastResult
+	}
+	throw lastResult!
 }
 
 // Fetchr? I hardly know her: https://github.com/NeunEinser/bingo

--- a/packages/core/src/service/fetcher.ts
+++ b/packages/core/src/service/fetcher.ts
@@ -52,6 +52,11 @@ export async function fetchWithCache(
 			} catch (e) {
 				logger.warn('[fetchWithCache] put cache', e)
 			}
+			try {
+				await cachedResponse?.body?.cancel()
+			} catch (e) {
+				logger.warn('[fetchWithCache] failed cancelling cachedResponse body stream', e)
+			}
 			return response
 		}
 	} catch (e) {

--- a/packages/core/src/service/fetcher.ts
+++ b/packages/core/src/service/fetcher.ts
@@ -8,11 +8,19 @@ const FETCH_TOTAL_TIMEOUT_MS = 15_000
 
 const STALE_HEADER = 'spyglassmc-is-stale'
 
+export interface FetcherOptions {
+	retryBaseMs?: number
+	retryMaxAttempts?: number
+	perTryTimeoutMs?: number
+	totalTimeoutMs?: number
+}
+
 export async function fetchWithCache(
 	{ web }: Externals,
 	logger: Logger,
 	input: RequestInfo | URL,
 	init?: RequestInit,
+	options?: FetcherOptions,
 ): Promise<Response> {
 	const cache = await web.getCache()
 	const request = new Request(input, init)
@@ -26,7 +34,7 @@ export async function fetchWithCache(
 	}
 	request.headers.set('user-agent', 'SpyglassMC (+https://spyglassmc.com)')
 	try {
-		const response = await fetchWithRetries(request)
+		const response = await fetchWithRetries(request, options)
 		if (response.status === 304) {
 			Dev.assertDefined(cachedResponse)
 			logger.info(`[fetchWithCache] reusing cache for ${request.url}`)
@@ -67,18 +75,26 @@ export function isStaleFetcherResponse(response: Response) {
 	return response.headers.has(STALE_HEADER)
 }
 
-async function fetchWithRetries(request: Request) {
+async function fetchWithRetries(
+	request: Request,
+	{
+		perTryTimeoutMs = FETCH_PER_TRY_TIMEOUT_MS,
+		retryBaseMs = FETCH_RETRY_BASE_MS,
+		retryMaxAttempts = FETCH_RETRY_MAX_ATTEMPTS,
+		totalTimeoutMs = FETCH_TOTAL_TIMEOUT_MS,
+	}: FetcherOptions = {},
+) {
 	let lastResult: Response | Error | undefined
-	const totalSignal = AbortSignal.timeout(FETCH_TOTAL_TIMEOUT_MS)
+	const totalSignal = AbortSignal.timeout(totalTimeoutMs)
 
-	Dev.assertTrue(FETCH_RETRY_MAX_ATTEMPTS > 0, 'Number of attempts must be greater than 0')
-	for (let i = 0; i < FETCH_RETRY_MAX_ATTEMPTS; i++) {
-		const isLastAttempt = i === FETCH_RETRY_MAX_ATTEMPTS - 1
+	Dev.assertTrue(retryMaxAttempts > 0, 'Number of attempts must be greater than 0')
+	for (let i = 0; i < retryMaxAttempts; i++) {
+		const isLastAttempt = i === retryMaxAttempts - 1
 		try {
 			lastResult = await fetch(request.clone(), {
 				signal: AbortSignal.any([
 					totalSignal,
-					AbortSignal.timeout(FETCH_PER_TRY_TIMEOUT_MS),
+					AbortSignal.timeout(perTryTimeoutMs),
 				]),
 			})
 			if (lastResult.status < 500) {
@@ -88,7 +104,7 @@ async function fetchWithRetries(request: Request) {
 			lastResult = e as Error
 		}
 		if (!isLastAttempt) {
-			await sleep(Math.round(Math.random() * (2 ** i) * FETCH_RETRY_BASE_MS))
+			await sleep(Math.round(Math.random() * (2 ** i) * retryBaseMs))
 		}
 	}
 

--- a/packages/core/test/common/externals/NodeJsExternals.spec.ts
+++ b/packages/core/test/common/externals/NodeJsExternals.spec.ts
@@ -1,0 +1,305 @@
+import { memfs } from 'memfs'
+import assert from 'node:assert/strict'
+import type fsp from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { type Externals, Uri } from '../../../lib/index.js'
+import { getNodeJsExternals } from '../../../lib/nodejs.js'
+import { assertUriExists, assertUriNotExists } from '../../utils.ts'
+
+const MOCK_TIMER_NOW = 1000213391729
+
+const mockExternals: () => { externals: Externals; nodeFsp: typeof fsp } = () => {
+	const nodeFsp = memfs({ 'root': {} }, '/').fs.promises as unknown as typeof fsp
+	return {
+		externals: getNodeJsExternals({
+			cacheRoot: 'file:///root/.cache/spyglassmc-nodejs/',
+			nodeFsp,
+		}),
+		nodeFsp,
+	}
+}
+
+const getCache = () => mockExternals().externals.web.getCache()
+
+describe('NodeJsExternals HttpCache', () => {
+	const uri1 = 'https://example.com/'
+	const uri2 = 'https://mcdoc.dev/'
+	const uri3 = 'https://spyglassmc.com/'
+	const defaultBytes = new Uint8Array([109, 101, 111, 119, 32, 58, 51])
+	const getDefaultResponse = () =>
+		new Response(defaultBytes, { status: 200, statusText: 'OK', headers: { etag: '67' } })
+	const alternativeBytes = new Uint8Array([103, 97, 121])
+	const getAlternativeResponse = () =>
+		new Response(alternativeBytes, { status: 200, statusText: 'OK', headers: { etag: '42' } })
+	const largeBytes = new Uint8Array(
+		new Array(100_000).fill(undefined).map(() => Math.floor(Math.random() * 256)),
+	)
+	const getLargeResponse = () =>
+		new Response(largeBytes, { status: 200, statusText: 'OK', headers: { etag: '42' } })
+	describe('put() & match()', () => {
+		describe('cache hit', () => {
+			const cases: readonly {
+				name?: string
+				put: RequestInfo | Uri
+				match: RequestInfo | Uri
+				bytes?: Uint8Array<ArrayBuffer>
+				status?: number
+				statusText?: string
+				useNewCacheInstance?: boolean
+			}[] = [
+				{ put: uri1, match: uri1 },
+				{ put: uri1, match: new Uri(uri1) },
+				{ put: uri1, match: new Request(uri1) },
+				{ put: new Uri(uri1), match: uri1 },
+				{ put: new Uri(uri1), match: new Uri(uri1) },
+				{ put: new Uri(uri1), match: new Request(uri1) },
+				{ put: new Request(uri1), match: uri1 },
+				{ put: new Request(uri1), match: new Uri(uri1) },
+				{ put: new Request(uri1), match: new Request(uri1) },
+
+				{ name: 'large bytes', put: uri1, match: uri1, bytes: largeBytes },
+				{ name: 'new cache instance', put: uri1, match: uri1, useNewCacheInstance: true },
+				{
+					name: 'range request',
+					put: new Request(uri1, { headers: { range: 'bytes=-22' } }),
+					match: new Request(uri1, { headers: { range: 'bytes=-22' } }),
+					status: 206,
+					statusText: 'Partial Content',
+				},
+			]
+			for (const { name, put, match, bytes, status, statusText, useNewCacheInstance } of cases) {
+				it(`Should hit for${name ? ` ${name}:` : ''} put ${put.constructor.name} ${put}; match ${match.constructor.name} ${match}`, async () => {
+					const response = new Response(bytes ?? defaultBytes, {
+						headers: { 'etag': '67' },
+						status: status ?? 200,
+						statusText: statusText ?? 'OK',
+					})
+					const externals = mockExternals().externals
+					const putterCache = await externals.web.getCache()
+					await putterCache.put(put, response)
+
+					const matcherCache = useNewCacheInstance
+						? await externals.web.getCache()
+						: putterCache
+					const cachedResponse = await matcherCache.match(match)
+					assert(cachedResponse)
+					assert.equal(cachedResponse.status, response.status)
+					assert.equal(cachedResponse.statusText, response.statusText)
+					assert.deepEqual([...cachedResponse.headers], [...response.headers])
+					const cachedBytes = await cachedResponse.bytes()
+					assert.deepEqual(cachedBytes, bytes ?? defaultBytes)
+				})
+			}
+		})
+
+		describe('cache miss', () => {
+			const cases: readonly {
+				name: string
+				put: RequestInfo | Uri
+				match: RequestInfo | Uri
+			}[] = [
+				{ name: 'diff URIs', put: uri1, match: uri2 },
+				{
+					name: 'diff ranges',
+					put: new Request(uri1, { headers: { range: 'bytes=-22' } }),
+					match: new Request(uri1, { headers: { range: 'bytes=-91' } }),
+				},
+				{
+					name: 'range v.s. no range',
+					put: new Request(uri1, { headers: { range: 'bytes=-22' } }),
+					match: uri1,
+				},
+				{
+					name: 'no range v.s. range',
+					put: uri1,
+					match: new Request(uri1, { headers: { range: 'bytes=-22' } }),
+				},
+			]
+			for (const { name, put, match } of cases) {
+				it(`Should miss for ${name}`, async () => {
+					const cache = await getCache()
+					await cache.put(put, getDefaultResponse())
+					const cachedResponse = await cache.match(match)
+					assert.equal(cachedResponse, undefined)
+				})
+			}
+		})
+	})
+
+	describe('put()', () => {
+		it('Should save index properly', async (t) => {
+			t.mock.timers.enable({ now: MOCK_TIMER_NOW, apis: ['Date'] })
+			const { externals, nodeFsp } = mockExternals()
+			const cache = await externals.web.getCache()
+			await cache.put(uri1, getDefaultResponse())
+
+			t.assert.snapshot(
+				await nodeFsp.readFile('/root/.cache/spyglassmc-nodejs/http/index.json', 'utf-8'),
+			)
+			assert.deepEqual(
+				new Uint8Array(
+					await nodeFsp.readFile(
+						'/root/.cache/spyglassmc-nodejs/http/objects/c4/c46a0660b3f0dc24e58eaf5c017082bd9488aeea',
+					),
+				),
+				defaultBytes,
+			)
+			assert.deepEqual(
+				await nodeFsp.readdir('/root/.cache/spyglassmc-nodejs/http/temp'),
+				[],
+			)
+		})
+
+		it('Should clean up legacy cache files', async () => {
+			const nodeFsp = memfs(
+				{
+					'root': {
+						'.cache': {
+							'spyglassmc-nodejs': {
+								'downloader': { 'mcje': { '1.12': { 'commands.json': '{}' } } },
+								'http': {
+									'aHR0cHM6Ly9hcGkuc3B5Z2xhc3NtYy5jb20vbWNqZS92ZXJzaW9ucw.bin': '{}',
+									'aHR0cHM6Ly9hcGkuc3B5Z2xhc3NtYy5jb20vbWNqZS92ZXJzaW9ucw.etag': 'foo',
+									'keep': 'foo',
+								},
+								'keep': 'foo',
+							},
+							'keep': 'foo',
+						},
+					},
+				},
+				'/',
+			).fs.promises as unknown as typeof fsp
+			const cache = await getNodeJsExternals({
+				cacheRoot: 'file:///root/.cache/spyglassmc-nodejs/',
+				nodeFsp,
+			}).web.getCache()
+			await cache.put(uri1, getDefaultResponse())
+			await assertUriNotExists(nodeFsp, '/root/.cache/spyglassmc-nodejs/downloader')
+			await assertUriNotExists(
+				nodeFsp,
+				'/root/.cache/spyglassmc-nodejs/http/aHR0cHM6Ly9hcGkuc3B5Z2xhc3NtYy5jb20vbWNqZS92ZXJzaW9ucw.bin',
+			)
+			await assertUriNotExists(
+				nodeFsp,
+				'/root/.cache/spyglassmc-nodejs/http/aHR0cHM6Ly9hcGkuc3B5Z2xhc3NtYy5jb20vbWNqZS92ZXJzaW9ucw.etag',
+			)
+			await assertUriExists(nodeFsp, '/root/.cache/spyglassmc-nodejs/http/keep')
+			await assertUriExists(nodeFsp, '/root/.cache/spyglassmc-nodejs/keep')
+			await assertUriExists(nodeFsp, '/root/.cache/keep')
+		})
+
+		it('Should clean up dangling object', async () => {
+			const { externals, nodeFsp } = mockExternals()
+			const cache = await externals.web.getCache()
+			await cache.put(uri1, getDefaultResponse())
+			await assertUriExists(
+				nodeFsp,
+				'/root/.cache/spyglassmc-nodejs/http/objects/c4/c46a0660b3f0dc24e58eaf5c017082bd9488aeea',
+			)
+			await cache.put(uri1, getAlternativeResponse())
+			await assertUriNotExists(
+				nodeFsp,
+				'/root/.cache/spyglassmc-nodejs/http/objects/c4/c46a0660b3f0dc24e58eaf5c017082bd9488aeea',
+			)
+		})
+
+		it('Should not clean up previous object if referenced by another entry', async () => {
+			const { externals, nodeFsp } = mockExternals()
+			const cache = await externals.web.getCache()
+			await cache.put(uri1, getDefaultResponse())
+			await cache.put(uri2, getDefaultResponse())
+			await assertUriExists(
+				nodeFsp,
+				'/root/.cache/spyglassmc-nodejs/http/objects/c4/c46a0660b3f0dc24e58eaf5c017082bd9488aeea',
+			)
+			await cache.put(uri1, getAlternativeResponse())
+			await assertUriExists(
+				nodeFsp,
+				'/root/.cache/spyglassmc-nodejs/http/objects/c4/c46a0660b3f0dc24e58eaf5c017082bd9488aeea',
+			)
+		})
+
+		it('Should no-op if response has no cache-related headers', async () => {
+			const cache = await getCache()
+			await cache.put(uri1, new Response(defaultBytes))
+			const cachedResponse = await cache.match(uri1)
+			assert.equal(cachedResponse, undefined)
+		})
+
+		it('Should work with sequential puts', async () => {
+			const cache = await getCache()
+			await cache.put(uri1, getDefaultResponse())
+			await cache.put(uri1, getDefaultResponse())
+			await cache.put(uri2, getAlternativeResponse())
+			await cache.put(uri3, getLargeResponse())
+			await cache.put(uri3, getLargeResponse())
+			const cachedResponse1 = await cache.match(uri1)
+			const cachedResponse2 = await cache.match(uri2)
+			const cachedResponse3 = await cache.match(uri3)
+			assert.deepEqual(await cachedResponse1?.bytes(), defaultBytes)
+			assert.deepEqual(await cachedResponse2?.bytes(), alternativeBytes)
+			assert.deepEqual(await cachedResponse3?.bytes(), largeBytes)
+		})
+
+		it('Should work with concurrent puts', async () => {
+			const cache = await getCache()
+			await Promise.all([
+				cache.put(uri1, getDefaultResponse()),
+				cache.put(uri1, getDefaultResponse()),
+				cache.put(uri2, getAlternativeResponse()),
+				cache.put(uri3, getLargeResponse()),
+				cache.put(uri3, getLargeResponse()),
+			])
+			const cachedResponse1 = await cache.match(uri1)
+			const cachedResponse2 = await cache.match(uri2)
+			const cachedResponse3 = await cache.match(uri3)
+			assert.deepEqual(await cachedResponse1?.bytes(), defaultBytes)
+			assert.deepEqual(await cachedResponse2?.bytes(), alternativeBytes)
+			assert.deepEqual(await cachedResponse3?.bytes(), largeBytes)
+		})
+
+		it('Should discard corrupted index', async (t) => {
+			t.mock.timers.enable({ now: MOCK_TIMER_NOW, apis: ['Date'] })
+			const { externals, nodeFsp } = mockExternals()
+			const cache = await externals.web.getCache()
+			await nodeFsp.mkdir('/root/.cache/spyglassmc-nodejs/http/', { recursive: true })
+			await nodeFsp.writeFile(
+				'/root/.cache/spyglassmc-nodejs/http/index.json',
+				'{"index":{"https://spyglassmc.com/":{"":{"status":200,"statusText":"OK","headers":{"etag":"42"},"sha1":"c46a0660b3f0dc24e58eaf5c017082bd9488aeea","cacheTime":1000213391729}}}}EXTRA_TOKEN',
+				{
+					encoding: 'utf-8',
+				},
+			)
+			await cache.put(uri1, getDefaultResponse())
+			t.assert.snapshot(
+				await nodeFsp.readFile('/root/.cache/spyglassmc-nodejs/http/index.json', 'utf-8'),
+			)
+		})
+	})
+
+	describe('match()', () => {
+		it('Should return undefined on miss', async (t) => {
+			const cache = await getCache()
+			const cachedResponse = await cache.match(uri1)
+			assert.equal(cachedResponse, undefined)
+		})
+
+		it('Should clean up entry on object miss', async (t) => {
+			t.mock.timers.enable({ now: MOCK_TIMER_NOW, apis: ['Date'] })
+			const { externals, nodeFsp } = mockExternals()
+			const cache = await externals.web.getCache()
+			await cache.put(uri1, getDefaultResponse())
+			t.assert.snapshot(
+				await nodeFsp.readFile('/root/.cache/spyglassmc-nodejs/http/index.json', 'utf-8'),
+			)
+
+			await nodeFsp.rm('/root/.cache/spyglassmc-nodejs/http/objects/', { recursive: true })
+			const cachedResponse = await cache.match(uri1)
+			assert.equal(cachedResponse, undefined)
+			t.assert.snapshot(
+				await nodeFsp.readFile('/root/.cache/spyglassmc-nodejs/http/index.json', 'utf-8'),
+			)
+		})
+	})
+})

--- a/packages/core/test/common/externals/NodeJsExternals.spec.ts.snapshot
+++ b/packages/core/test/common/externals/NodeJsExternals.spec.ts.snapshot
@@ -1,0 +1,19 @@
+exports[`NodeJsExternals HttpCache > match() > Should clean up entry on object miss 1`] = `
+{"index":{"https://example.com/":{"":{"status":200,"statusText":"OK","headers":{"etag":"67"},"sha1":"c46a0660b3f0dc24e58eaf5c017082bd9488aeea","cacheTime":1000213391729}}}}
+
+`;
+
+exports[`NodeJsExternals HttpCache > match() > Should clean up entry on object miss 2`] = `
+{"index":{}}
+
+`;
+
+exports[`NodeJsExternals HttpCache > put() > Should discard corrupted index 1`] = `
+{"index":{"https://example.com/":{"":{"status":200,"statusText":"OK","headers":{"etag":"67"},"sha1":"c46a0660b3f0dc24e58eaf5c017082bd9488aeea","cacheTime":1000213391729}}}}
+
+`;
+
+exports[`NodeJsExternals HttpCache > put() > Should save index properly 1`] = `
+{"index":{"https://example.com/":{"":{"status":200,"statusText":"OK","headers":{"etag":"67"},"sha1":"c46a0660b3f0dc24e58eaf5c017082bd9488aeea","cacheTime":1000213391729}}}}
+
+`;

--- a/packages/core/test/service/fetcher.spec.ts
+++ b/packages/core/test/service/fetcher.spec.ts
@@ -1,0 +1,158 @@
+import { memfs } from 'memfs'
+import assert from 'node:assert/strict'
+import type fsp from 'node:fs/promises'
+import { after, before, beforeEach, describe, it } from 'node:test'
+import type { Dispatcher } from 'undici'
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici'
+import { type Externals, type FetcherOptions, fetchWithCache, Logger } from '../../lib/index.js'
+import { getNodeJsExternals } from '../../lib/nodejs.js'
+
+describe('fetcher', () => {
+	let originalDispatcher: Dispatcher
+	let agent: MockAgent
+
+	const logger = Logger.create()
+	const mockExternals: () => { externals: Externals; nodeFsp: typeof fsp } = () => {
+		const nodeFsp = memfs({ 'root': {} }, '/').fs.promises as unknown as typeof fsp
+		return {
+			externals: getNodeJsExternals({
+				cacheRoot: 'file:///root/.cache/spyglassmc-nodejs/',
+				nodeFsp,
+			}),
+			nodeFsp,
+		}
+	}
+	const TEST_FETCHER_OPTIONS: FetcherOptions = {
+		perTryTimeoutMs: 50,
+		retryBaseMs: 0,
+		retryMaxAttempts: 2,
+		totalTimeoutMs: 50,
+	}
+
+	before(() => {
+		originalDispatcher = getGlobalDispatcher()
+	})
+	beforeEach(() => {
+		agent = new MockAgent()
+		setGlobalDispatcher(agent)
+	})
+	after(() => {
+		setGlobalDispatcher(originalDispatcher!)
+	})
+
+	describe('No existing cache entry', () => {
+		it('Should return response when fetch is ok on first attempt', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 200,
+						data: 'example data',
+					}
+				})
+				.times(1)
+
+			const { externals } = mockExternals()
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.deepEqual(await response.text(), 'example data')
+		})
+
+		it('Should return response when fetch is ok on retry', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 500,
+						data: 'example error',
+					}
+				})
+				.times(1)
+
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 200,
+						data: 'example data',
+					}
+				})
+				.times(1)
+
+			const { externals } = mockExternals()
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.deepEqual(await response.text(), 'example data')
+		})
+
+		it('Should throw exception when fetch is not ok after all retries', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 500,
+						data: 'example error',
+					}
+				})
+				.times(2)
+
+			const { externals } = mockExternals()
+			await assert.rejects(async () => {
+				await fetchWithCache(
+					externals,
+					logger,
+					'https://example.com/foo',
+					undefined,
+					TEST_FETCHER_OPTIONS,
+				)
+			}, { name: 'TypeError', message: '500 example error' })
+
+			it('Should throw exception when fetch times out after all retries', async () => {
+				agent
+					.get('https://example.com')
+					.intercept({ path: '/foo' })
+					.reply(() => {
+						return {
+							statusCode: 500,
+							data: 'example error',
+						}
+					})
+					.delay(100)
+					.times(2)
+
+				const { externals } = mockExternals()
+				await assert.rejects(async () => {
+					await fetchWithCache(
+						externals,
+						logger,
+						'https://example.com/foo',
+						undefined,
+						TEST_FETCHER_OPTIONS,
+					)
+				}, { name: 'TimeoutError', message: 'The operation was aborted due to timeout' })
+			})
+		})
+	})
+
+	describe('Has existing cache entry', () => {
+		// cache exists, 304, returned
+		// cache exists, ok on first attempt, returned & updated cache
+		// cache exists, ok on retry, returned & updated cache
+		// cache exists, not ok, stale response returned
+		// cache exists, timeout, stale response returned
+	})
+})

--- a/packages/core/test/service/fetcher.spec.ts
+++ b/packages/core/test/service/fetcher.spec.ts
@@ -120,39 +120,168 @@ describe('fetcher', () => {
 					TEST_FETCHER_OPTIONS,
 				)
 			}, { name: 'TypeError', message: '500 example error' })
+		})
 
-			it('Should throw exception when fetch times out after all retries', async () => {
-				agent
-					.get('https://example.com')
-					.intercept({ path: '/foo' })
-					.reply(() => {
-						return {
-							statusCode: 500,
-							data: 'example error',
-						}
-					})
-					.delay(100)
-					.times(2)
+		it('Should throw exception when fetch times out after all retries', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 200,
+						data: 'example data',
+					}
+				})
+				.delay(100)
+				.times(2)
 
-				const { externals } = mockExternals()
-				await assert.rejects(async () => {
-					await fetchWithCache(
-						externals,
-						logger,
-						'https://example.com/foo',
-						undefined,
-						TEST_FETCHER_OPTIONS,
-					)
-				}, { name: 'TimeoutError', message: 'The operation was aborted due to timeout' })
-			})
+			const { externals } = mockExternals()
+			await assert.rejects(async () => {
+				await fetchWithCache(
+					externals,
+					logger,
+					'https://example.com/foo',
+					undefined,
+					TEST_FETCHER_OPTIONS,
+				)
+			}, { name: 'TimeoutError', message: 'The operation was aborted due to timeout' })
 		})
 	})
 
 	describe('Has existing cache entry', () => {
-		// cache exists, 304, returned
-		// cache exists, ok on first attempt, returned & updated cache
-		// cache exists, ok on retry, returned & updated cache
-		// cache exists, not ok, stale response returned
-		// cache exists, timeout, stale response returned
+		let externals!: Externals
+
+		beforeEach(async () => {
+			externals = mockExternals().externals
+			const cache = await externals.web.getCache()
+			await cache.put(
+				'https://example.com/foo',
+				new Response('cached data', {
+					status: 200,
+					statusText: 'OK',
+					headers: { etag: '67' },
+				}),
+			)
+		})
+
+		it('Should return cache on 304', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 304,
+					}
+				})
+				.times(1)
+
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.equal(await response.text(), 'cached data')
+		})
+
+		it('Should return remote data on ok', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 200,
+						data: 'remote data',
+					}
+				})
+				.times(1)
+
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.equal(await response.text(), 'remote data')
+		})
+
+		it('Should return remote data on retry ok', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 500,
+						data: 'remote error',
+					}
+				})
+				.times(1)
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 200,
+						data: 'remote data',
+					}
+				})
+				.times(1)
+
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.equal(await response.text(), 'remote data')
+		})
+
+		it('Should return stale cache data when remote error', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 500,
+						data: 'remote error',
+					}
+				})
+				.times(2)
+
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.equal(await response.text(), 'cached data')
+		})
+
+		it('Should return stale cache data when remote times out', async () => {
+			agent
+				.get('https://example.com')
+				.intercept({ path: '/foo' })
+				.reply(() => {
+					return {
+						statusCode: 200,
+						data: 'remote data',
+					}
+				})
+				.delay(100)
+				.times(2)
+
+			const response = await fetchWithCache(
+				externals,
+				logger,
+				'https://example.com/foo',
+				undefined,
+				TEST_FETCHER_OPTIONS,
+			)
+			assert.equal(await response.text(), 'cached data')
+		})
 	})
 })

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -29,7 +29,7 @@ import {
 	VanillaConfig,
 } from '@spyglassmc/core'
 import { getNodeJsExternals, NodeJsExternals } from '@spyglassmc/core/lib/nodejs.js'
-import { fail } from 'node:assert/strict'
+import assert, { fail } from 'node:assert/strict'
 import type fsp from 'node:fs/promises'
 import type { TestContext } from 'node:test'
 import type { URL } from 'node:url'
@@ -330,4 +330,23 @@ export function mockExternals(
 	return getNodeJsExternals({
 		nodeFsp: nodeFsp as unknown as typeof fsp,
 	})
+}
+
+export async function assertUriExists(nodeFsp: typeof fsp, uri: string) {
+	try {
+		await nodeFsp.access(uri)
+	} catch (e) {
+		fail(e as Error)
+	}
+}
+
+export async function assertUriNotExists(nodeFsp: typeof fsp, uri: string) {
+	try {
+		await nodeFsp.access(uri)
+		fail(`Expected ${uri} to not exist`)
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+			fail(e as Error)
+		}
+	}
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -34,13 +34,13 @@ let workspaceFolders!: ls.WorkspaceFolder[]
 let projectRoots!: core.RootUriString[]
 let hasShutdown = false
 
-const externals = getNodeJsExternals({ cacheRoot })
 const logger: core.Logger = {
 	error: (msg: any, ...args: any[]): void => connection.console.error(util.format(msg, ...args)),
 	info: (msg: any, ...args: any[]): void => connection.console.info(util.format(msg, ...args)),
 	log: (msg: any, ...args: any[]): void => connection.console.log(util.format(msg, ...args)),
 	warn: (msg: any, ...args: any[]): void => connection.console.warn(util.format(msg, ...args)),
 }
+const externals = getNodeJsExternals({ cacheRoot, logger })
 let service!: core.Service
 
 function buildSemanticTokensCapability(isDynamic: boolean): ls.SemanticTokensRegistrationOptions {


### PR DESCRIPTION
This in preparation for https://github.com/SpyglassMC/Spyglass/issues/1938.

* `HttpCache` / `fetcher`: Adds support for caching based on `last-modified` / `if-modified-since` headers in addition to the existing `etag` / `if-none-match` headers, as the Mojang API uses the time based ones instead of `etag`
* `HttpCache`: Adds support for caching partial requests with the `Range` header, which will be used for extracting `version.json` from client Jar files without downloading the whole 30MB+ thing
* `HttpCache`: Switches to using an index file with a content-addressable storage instead of having the file names themselves as indexing keys in base64url encoding. This was mainly changed due to concerns regarding how to encode both the request URI and the `Range` header in the file name without making the file paths too long (which could cause problems on Windows). Also makes it easier to implement cache eviction in the future if we ever need to as we wouldn't need to walk the full file tree to find out what's cached.
* `fetcher`: Adds retries for network-level problems