### PR TITLE
⬆️ TypeScript 7

### DIFF
--- a/.packages.json
+++ b/.packages.json
@@ -1,4 +1,15 @@
 {
+	"benchmarks": {
+		"dependencies": [
+			"core",
+			"java-edition",
+			"json",
+			"mcdoc"
+		],
+		"released": {
+			"private": true
+		}
+	},
 	"core": {
 		"dependencies": [
 			"locales"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@types/webpack": "^5.28.1",
 				"@typescript-eslint/eslint-plugin": "^8.59.2",
 				"@typescript-eslint/parser": "^8.59.2",
-				"@typescript/native-preview": "^7.0.0-dev.20260421.2",
+				"@typescript/native-preview": "^7.0.0-dev.20260511.1",
 				"benchmark": "^2.1.4",
 				"circular-dependency-plugin": "^5.2.2",
 				"dprint": "^0.45.1",
@@ -3027,28 +3027,31 @@
 			}
 		},
 		"node_modules/@typescript/native-preview": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-cUyY4Sr6065280lB6hCwTMCBMTxlEIGjSLzHym28yikA5sFiEsAzlwiU0i+XkTUIqr5K5M/SzSJiioDN+vpjtA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsgo": "bin/tsgo.js"
 			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
 			"optionalDependencies": {
-				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260511.1",
+				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260511.1",
+				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260511.1",
+				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260511.1",
+				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260511.1",
+				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260511.1",
+				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260511.1"
 			}
 		},
 		"node_modules/@typescript/native-preview-darwin-arm64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-SYrqVOlapDxDG7FzHBIJbfgaix+mXPkYzYGqwpz/TAhoPA7sgbfAoGLaqi3ut9N88C/OYNhEX4tjz/0PC9i1nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3057,12 +3060,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-darwin-x64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-zIe31OYgBvkgTIQEwJtKim6SYyuVTkr+9fK/87hVwKN15X3Ikjeh0C0g2W/Vl4rXeMvy95wBGDN1jpW11DIvgg==",
 			"cpu": [
 				"x64"
 			],
@@ -3071,12 +3077,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-linux-arm": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-02b45lpPmYf125PvcnK67WW93N55qwKmtInwfVefV997S17Ib3h6hlCW4e24BDhNsGRCSLhPA4Lu7ZvTq5pLkw==",
 			"cpu": [
 				"arm"
 			],
@@ -3085,12 +3094,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-linux-arm64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-YbmCQXGYkDChGFG7hXJzIgmRjtU1kE5VK/+k322nGnbq4ePqSjS3dS0+ehPATmvfO1XjCDfh3ekED+AtmWk6aQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3099,12 +3111,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-linux-x64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-e+TweaVJFaM96tV1UM1kRfk2y8QBkZtz7+0wcxrDGmyJz3IIRUlg1btocaBkhsmVtQPXMr37RutBBMgpl3vgUg==",
 			"cpu": [
 				"x64"
 			],
@@ -3113,12 +3128,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-win32-arm64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-zgkoGiCpOrly5h8ghcuu6ZNSfrnRqtHoCq584Q92+s4D/j1MU3oKkGPvmkezp5Mj2v7ffR9AjU+lWRDkrfm6eA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3127,12 +3145,15 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-win32-x64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+			"version": "7.0.0-dev.20260511.1",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260511.1.tgz",
+			"integrity": "sha512-SUm7iVYzKaflol+QwH0Ny5jZtco6PJduI+h/TEg0sgBJzVBa+9RN4I9+Xu9v+EJ1bci3XI7835IRdSP36lCgCw==",
 			"cpu": [
 				"x64"
 			],
@@ -3141,7 +3162,10 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@typespec/ts-http-runtime": {
 			"version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
 		"ansible:prod:verbose": "ansible-playbook -i ansible/inventory-prod.yml --extra-vars \"@ansible/secrets.yml.vault\" --ask-vault-pass ansible/playbook.yml -vvv",
 		"build": "wireit",
 		"build:dev": "wireit",
-		"build:tsgo": "tsgo -b packages",
+		"build:tsc6": "tsc -b packages",
 		"watch": "npm run build:dev --watch",
-		"clean": "tsc -b packages --clean",
+		"clean": "tsgo -b packages --clean",
 		"clean:full": "rm -rf packages/*/lib packages/*/out packages/*/dist packages/*/test-out packages/*/*.tsbuildinfo .wireit packages/*/.wireit",
 		"commit": "gitmoji -c",
 		"docs:install": "cd docs && (bundle || true) && cd ..",
@@ -48,7 +48,7 @@
 		},
 		"build:packages": {
 			"$comment": "This script is used as a dependency by ./packages/playground:build and ./packages/vscode-extension:build",
-			"command": "tsc -b packages",
+			"command": "tsgo -b packages",
 			"files": [
 				"packages/*/src/**/*.*",
 				"packages/*/test/**/*.*"
@@ -64,7 +64,7 @@
 		"@types/webpack": "^5.28.1",
 		"@typescript-eslint/eslint-plugin": "^8.59.2",
 		"@typescript-eslint/parser": "^8.59.2",
-		"@typescript/native-preview": "^7.0.0-dev.20260421.2",
+		"@typescript/native-preview": "^7.0.0-dev.20260511.1",
 		"benchmark": "^2.1.4",
 		"circular-dependency-plugin": "^5.2.2",
 		"dprint": "^0.45.1",

--- a/packages/benchmarks/src/tsconfig.json
+++ b/packages/benchmarks/src/tsconfig.json
@@ -3,5 +3,16 @@
 	"compilerOptions": {
 		"noEmit": false,
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../java-edition"
+		},
+		{
+			"path": "../../json"
+		}
+	]
 }

--- a/packages/benchmarks/src/tsconfig.json
+++ b/packages/benchmarks/src/tsconfig.json
@@ -6,13 +6,16 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../java-edition"
+			"path": "../../java-edition/src"
 		},
 		{
-			"path": "../../json"
+			"path": "../../json/src"
+		},
+		{
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/benchmarks/tsconfig.json
+++ b/packages/benchmarks/tsconfig.json
@@ -3,9 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		}
 	]

--- a/packages/benchmarks/tsconfig.json
+++ b/packages/benchmarks/tsconfig.json
@@ -3,15 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../java-edition"
-		},
-		{
-			"path": "../json"
-		},
-		{
 			"path": "../mcdoc"
 		},
 		{

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -5,7 +5,7 @@
 	},
 	"references": [
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		}
 	]
 }

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -2,5 +2,10 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../locales"
+		}
+	]
 }

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,5 +1,12 @@
 {
 	"extends": "../../tsconfig-type-strip",
+	"compilerOptions": {
+		// Tests from other packages may import from @spyglassmc/core/test/utils.ts, so declaration emit
+		// needs to be enabled here.
+		"noEmit": false,
+		"outDir": "../test-out",
+		"emitDeclarationOnly": true
+	},
 	"references": [
 		{
 			"path": "../src"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,9 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../locales"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/discord-bot/src/tsconfig.json
+++ b/packages/discord-bot/src/tsconfig.json
@@ -5,16 +5,16 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../java-edition"
+			"path": "../../java-edition/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/discord-bot/src/tsconfig.json
+++ b/packages/discord-bot/src/tsconfig.json
@@ -2,5 +2,19 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../java-edition"
+		},
+		{
+			"path": "../../locales"
+		},
+		{
+			"path": "../../mcdoc"
+		}
+	]
 }

--- a/packages/discord-bot/tsconfig.json
+++ b/packages/discord-bot/tsconfig.json
@@ -3,18 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../java-edition"
-		},
-		{
-			"path": "../locales"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		}
 	]

--- a/packages/java-edition/src/tsconfig.json
+++ b/packages/java-edition/src/tsconfig.json
@@ -5,22 +5,22 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../json"
+			"path": "../../json/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		},
 		{
-			"path": "../../mcfunction"
+			"path": "../../mcfunction/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		},
 		{
-			"path": "../../nbt"
+			"path": "../../nbt/src"
 		}
 	]
 }

--- a/packages/java-edition/src/tsconfig.json
+++ b/packages/java-edition/src/tsconfig.json
@@ -2,5 +2,25 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../json"
+		},
+		{
+			"path": "../../locales"
+		},
+		{
+			"path": "../../mcfunction"
+		},
+		{
+			"path": "../../mcdoc"
+		},
+		{
+			"path": "../../nbt"
+		}
+	]
 }

--- a/packages/java-edition/test/tsconfig.json
+++ b/packages/java-edition/test/tsconfig.json
@@ -9,6 +9,9 @@
 	],
 	"references": [
 		{
+			"path": "../../core/test"
+		},
+		{
 			"path": "../src"
 		}
 	]

--- a/packages/java-edition/tsconfig.json
+++ b/packages/java-edition/tsconfig.json
@@ -3,24 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../json"
-		},
-		{
-			"path": "../locales"
-		},
-		{
-			"path": "../mcfunction"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
-			"path": "../nbt"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/json/src/tsconfig.json
+++ b/packages/json/src/tsconfig.json
@@ -2,5 +2,16 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../locales"
+		},
+		{
+			"path": "../../mcdoc"
+		}
+	]
 }

--- a/packages/json/src/tsconfig.json
+++ b/packages/json/src/tsconfig.json
@@ -5,13 +5,13 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/json/test/tsconfig.json
+++ b/packages/json/test/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../../tsconfig-type-strip",
 	"references": [
 		{
+			"path": "../../core/test"
+		},
+		{
 			"path": "../src"
 		}
 	]

--- a/packages/json/tsconfig.json
+++ b/packages/json/tsconfig.json
@@ -3,15 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../locales"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/language-server/src/tsconfig.json
+++ b/packages/language-server/src/tsconfig.json
@@ -5,16 +5,16 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../java-edition"
+			"path": "../../java-edition/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/language-server/src/tsconfig.json
+++ b/packages/language-server/src/tsconfig.json
@@ -2,5 +2,19 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../java-edition"
+		},
+		{
+			"path": "../../locales"
+		},
+		{
+			"path": "../../mcdoc"
+		}
+	]
 }

--- a/packages/language-server/test/tsconfig.json
+++ b/packages/language-server/test/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../../tsconfig-type-strip",
 	"references": [
 		{
+			"path": "../../core/test"
+		},
+		{
 			"path": "../src"
 		}
 	]

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -3,18 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../java-edition"
-		},
-		{
-			"path": "../locales"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/mcdoc-cli/package.json
+++ b/packages/mcdoc-cli/package.json
@@ -25,7 +25,7 @@
     "release": "npm publish",
     "release:dry": "npm publish --tag latest --dry-run",
     "setup": "git clone https://github.com/SpyglassMC/vanilla-mcdoc",
-    "test": "rm -rf out/generated/module/* && cd vanilla-mcdoc && git pull && cd .. && tsc -b && node lib/index.js generate vanilla-mcdoc/ -l -m -p"
+    "test": "rm -rf out/generated/module/* && cd vanilla-mcdoc && git pull && cd .. && tsgo -b && node lib/index.js generate vanilla-mcdoc/ -l -m -p"
   },
   "dependencies": {
     "fs-extra": "^11.1.1",

--- a/packages/mcdoc-cli/src/tsconfig.json
+++ b/packages/mcdoc-cli/src/tsconfig.json
@@ -2,5 +2,13 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../mcdoc"
+		}
+	]
 }

--- a/packages/mcdoc-cli/src/tsconfig.json
+++ b/packages/mcdoc-cli/src/tsconfig.json
@@ -5,10 +5,10 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/mcdoc-cli/tsconfig.json
+++ b/packages/mcdoc-cli/tsconfig.json
@@ -3,12 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/mcdoc/src/tsconfig.json
+++ b/packages/mcdoc/src/tsconfig.json
@@ -2,5 +2,13 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../locales"
+		}
+	]
 }

--- a/packages/mcdoc/src/tsconfig.json
+++ b/packages/mcdoc/src/tsconfig.json
@@ -5,10 +5,10 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		}
 	]
 }

--- a/packages/mcdoc/test/tsconfig.json
+++ b/packages/mcdoc/test/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../../tsconfig-type-strip",
 	"references": [
 		{
+			"path": "../../core/test"
+		},
+		{
 			"path": "../src"
 		}
 	]

--- a/packages/mcdoc/tsconfig.json
+++ b/packages/mcdoc/tsconfig.json
@@ -3,12 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../locales"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/mcfunction/src/tsconfig.json
+++ b/packages/mcfunction/src/tsconfig.json
@@ -2,5 +2,13 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../locales"
+		}
+	]
 }

--- a/packages/mcfunction/src/tsconfig.json
+++ b/packages/mcfunction/src/tsconfig.json
@@ -5,10 +5,10 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		}
 	]
 }

--- a/packages/mcfunction/test/tsconfig.json
+++ b/packages/mcfunction/test/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../../tsconfig-type-strip",
 	"references": [
 		{
+			"path": "../../core/test"
+		},
+		{
 			"path": "../src"
 		}
 	]

--- a/packages/mcfunction/tsconfig.json
+++ b/packages/mcfunction/tsconfig.json
@@ -3,12 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../locales"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/nbt/src/tsconfig.json
+++ b/packages/nbt/src/tsconfig.json
@@ -2,5 +2,16 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../lib"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../locales"
+		},
+		{
+			"path": "../../mcdoc"
+		}
+	]
 }

--- a/packages/nbt/src/tsconfig.json
+++ b/packages/nbt/src/tsconfig.json
@@ -5,13 +5,13 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/nbt/test/tsconfig.json
+++ b/packages/nbt/test/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../../tsconfig-type-strip",
 	"references": [
 		{
+			"path": "../../core/test"
+		},
+		{
 			"path": "../src"
 		}
 	]

--- a/packages/nbt/tsconfig.json
+++ b/packages/nbt/tsconfig.json
@@ -3,15 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../locales"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		},
 		{

--- a/packages/playground/src/tsconfig.json
+++ b/packages/playground/src/tsconfig.json
@@ -5,16 +5,16 @@
 	},
 	"references": [
 		{
-			"path": "../../core"
+			"path": "../../core/src"
 		},
 		{
-			"path": "../../java-edition"
+			"path": "../../java-edition/src"
 		},
 		{
-			"path": "../../locales"
+			"path": "../../locales/src"
 		},
 		{
-			"path": "../../mcdoc"
+			"path": "../../mcdoc/src"
 		}
 	]
 }

--- a/packages/playground/src/tsconfig.json
+++ b/packages/playground/src/tsconfig.json
@@ -2,5 +2,19 @@
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
 		"outDir": "../out"
-	}
+	},
+	"references": [
+		{
+			"path": "../../core"
+		},
+		{
+			"path": "../../java-edition"
+		},
+		{
+			"path": "../../locales"
+		},
+		{
+			"path": "../../mcdoc"
+		}
+	]
 }

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -3,18 +3,6 @@
 	"files": [],
 	"references": [
 		{
-			"path": "../core"
-		},
-		{
-			"path": "../java-edition"
-		},
-		{
-			"path": "../locales"
-		},
-		{
-			"path": "../mcdoc"
-		},
-		{
 			"path": "src"
 		}
 	]

--- a/packages/vscode-extension/src/tsconfig.json
+++ b/packages/vscode-extension/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig-base",
+	"compilerOptions": {
+		"outDir": "../out",
+		"declarationMap": false,
+		"sourceMap": false
+	},
+	"references": [
+		{
+			"path": "../../language-server"
+		}
+	]
+}

--- a/packages/vscode-extension/src/tsconfig.json
+++ b/packages/vscode-extension/src/tsconfig.json
@@ -7,7 +7,7 @@
 	},
 	"references": [
 		{
-			"path": "../../language-server"
+			"path": "../../language-server/src"
 		}
 	]
 }

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,17 +1,8 @@
 {
-	"extends": "../tsconfig-base",
-	"compilerOptions": {
-		"rootDir": "src",
-		"outDir": "out",
-		"declarationMap": false,
-		"sourceMap": false
-	},
-	"files": [
-		"src/extension.mts"
-	],
+	"files": [],
 	"references": [
 		{
-			"path": "../language-server"
+			"path": "src"
 		}
 	]
 }

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -9,8 +9,11 @@ export interface PackageInfo {
 	dependencies?: string[]
 	devDependencies?: string[]
 	released?: {
+		private?: false
 		commit: string
 		version: PackageVersion
+	} | {
+		private: true
 	}
 }
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -193,7 +193,9 @@ async function main(): Promise<void> {
 			packagesToBump.set(name, type)
 			for (const [key, info] of Object.entries(packagesInfo)) {
 				const dependencies = [...info.dependencies ?? [], ...info.devDependencies ?? []]
-				if (dependencies.includes(name) && !packagesToBump.has(key)) {
+				if (
+					dependencies.includes(name) && !packagesToBump.has(key) && !info.released?.private
+				) {
 					console.log(`${key}: patch bump due to its dependency on ${name}`)
 					addPackageToBump(key, BumpType.Patch)
 				}
@@ -203,6 +205,10 @@ async function main(): Promise<void> {
 
 	for (const [key, info] of Object.entries(packagesInfo)) {
 		maxPackageNameLength = Math.max(maxPackageNameLength, key.length)
+		if (info.released?.private) {
+			console.log(`${key}: skip analyzing commits for private package`)
+			continue
+		}
 		const commits = await getPackageCommits(key)
 		console.log(`${key}: analyzing commits...`)
 		if (!info.released) {
@@ -234,12 +240,16 @@ async function main(): Promise<void> {
 	const versionSummaries: string[] = []
 	for (const [key, info] of Object.entries(packagesInfo)) {
 		const displayableKey = key + ':' + ' '.repeat(maxPackageNameLength - key.length)
+		if (info.released?.private) {
+			versionSummaries.push(`${displayableKey} (private)`)
+			continue
+		}
 		const type = packagesToBump.get(key)
 		if (type === undefined) {
 			versionSummaries.push(`${displayableKey} ${info.released!.version} (unchanged)`)
 		} else {
 			const oldVersion = info.released!.version
-			info.released!.version = bumpVersion(packagesInfo[key].released!.version, type)
+			info.released!.version = bumpVersion(oldVersion, type)
 			versionSummaries.push(
 				`${displayableKey} ${oldVersion} -> ${info.released!.version} (${
 					bumpTypeToString(type)

--- a/scripts/set_tsconfig_references.ts
+++ b/scripts/set_tsconfig_references.ts
@@ -15,18 +15,18 @@ for (const key of packageNames) {
 		? [...dependencies ?? [], ...devDependencies ?? []]
 		: undefined
 	const p = getPackagePath(key)
-	const tsconfigPath = path.join(p, 'tsconfig.json')
-	const tsconfig: { [key: string]: any; references?: { path: string }[] } = JSON.parse(
-		fs.readFileSync(tsconfigPath, 'utf-8'),
+	const srcTsconfigPath = path.join(p, 'src', 'tsconfig.json')
+	const srcTsconfig: { [key: string]: any; references?: { path: string }[] } = JSON.parse(
+		fs.readFileSync(srcTsconfigPath, 'utf-8'),
 	)
-	if (tsconfig.references) {
-		tsconfig.references = tsconfig.references.filter(v => !v.path.startsWith('../'))
+	if (srcTsconfig.references) {
+		srcTsconfig.references = srcTsconfig.references.filter(v => !v.path.startsWith('../../'))
 	}
 	if (allDependencies) {
-		tsconfig.references = tsconfig.references ?? []
-		tsconfig.references.unshift(...allDependencies.map(d => ({ path: `../${d}` })))
+		srcTsconfig.references = srcTsconfig.references ?? []
+		srcTsconfig.references.unshift(...allDependencies.map(d => ({ path: `../../${d}` })))
 	}
-	fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, undefined, '\t') + '\n', {
+	fs.writeFileSync(srcTsconfigPath, JSON.stringify(srcTsconfig, undefined, '\t') + '\n', {
 		encoding: 'utf-8',
 	})
 }

--- a/scripts/set_tsconfig_references.ts
+++ b/scripts/set_tsconfig_references.ts
@@ -24,7 +24,7 @@ for (const key of packageNames) {
 	}
 	if (allDependencies) {
 		srcTsconfig.references = srcTsconfig.references ?? []
-		srcTsconfig.references.unshift(...allDependencies.map(d => ({ path: `../../${d}` })))
+		srcTsconfig.references.unshift(...allDependencies.map(d => ({ path: `../../${d}/src` })))
 	}
 	fs.writeFileSync(srcTsconfigPath, JSON.stringify(srcTsconfig, undefined, '\t') + '\n', {
 		encoding: 'utf-8',


### PR DESCRIPTION
Update tsconfig project references to reference dependencies at `src` and `test` level instead of at package level. See also [microsoft/typescript-go#3795](https://redirect.github.com/microsoft/typescript-go/issues/3795)

The build now passes with `tsgo`, so switched build scripts to use `tsgo` instead.