### PR TITLE
♻️ Collect and update hardcoded mcdoc type references

### DIFF
--- a/packages/java-edition/src/json/checker/index.ts
+++ b/packages/java-edition/src/json/checker/index.ts
@@ -1,6 +1,6 @@
 import type * as core from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
-import type * as mcdoc from '@spyglassmc/mcdoc'
+import * as mcdoc from '@spyglassmc/mcdoc'
 import { dissectUri, reportDissectError } from '../../binder/index.js'
 
 function createTagDefinition(registry: string): mcdoc.McdocType {
@@ -13,7 +13,7 @@ function createTagDefinition(registry: string): mcdoc.McdocType {
 	}
 	return {
 		kind: 'concrete',
-		child: { kind: 'reference', path: '::java::data::tag::Tag' },
+		child: mcdoc.typeRef('tag'),
 		typeArgs: [{ kind: 'string', attributes: [{ name: 'id', value: id }] }],
 	}
 }
@@ -21,7 +21,7 @@ function createTagDefinition(registry: string): mcdoc.McdocType {
 export const file: core.Checker<json.JsonFileNode> = (node, ctx) => {
 	const child = node.children[0]
 	if (ctx.doc.uri.endsWith('/pack.mcmeta')) {
-		const type: mcdoc.McdocType = { kind: 'reference', path: '::java::pack::Pack' }
+		const type: mcdoc.McdocType = mcdoc.typeRef('pack_meta')
 		return json.checker.index(type)(child, ctx)
 	}
 	const parts = dissectUri(ctx.doc.uri, ctx)

--- a/packages/java-edition/src/mcfunction/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcfunction/mcdocAttributes.ts
@@ -87,7 +87,7 @@ export function registerMcdocAttributes(meta: core.MetaRegistry, rootTreeNode: m
 					type: 'json:typed',
 					range: res.range,
 					children: [res],
-					targetType: { kind: 'reference', path: '::java::server::util::text::Text' },
+					targetType: mcdoc.typeRef('text_component'),
 				} satisfies json.TypedJsonNode)),
 				localize('text-component'),
 			),

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -2,6 +2,7 @@ import * as core from '@spyglassmc/core'
 import { sequence } from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
 import { localeQuote, localize } from '@spyglassmc/locales'
+import * as mcdoc from '@spyglassmc/mcdoc'
 import * as mcf from '@spyglassmc/mcfunction'
 import * as nbt from '@spyglassmc/nbt'
 import { ReleaseVersion } from '../../dependency/index.js'
@@ -161,7 +162,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:column_pos':
 			return wrap(vector({ dimension: 2, integersOnly: true }))
 		case 'minecraft:component':
-			return wrap(typeRefParser('::java::server::util::text::Text'))
+			return wrap(typeRefParser(mcdoc.typeRefPath('text_component')))
 		case 'minecraft:dialog':
 			return wrap(resourceOrInline('dialog'))
 		case 'minecraft:dimension':
@@ -275,7 +276,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:slot_source':
 			return wrap(slotSource)
 		case 'minecraft:style':
-			return wrap(typeRefParser('::java::server::util::text::TextStyle'))
+			return wrap(typeRefParser(mcdoc.typeRefPath('text_style')))
 		case 'minecraft:swizzle':
 			return wrap(commandLiteral({ pool: SwizzleArgumentValues }))
 		case 'minecraft:team':

--- a/packages/java-edition/test/mcfunction/parser/argument/minecraftComponent.spec.ts.snapshot
+++ b/packages/java-edition/test/mcfunction/parser/argument/minecraftComponent.spec.ts.snapshot
@@ -70,7 +70,7 @@ exports[`mcfunction argument parser > minecraft:component > Parse '[\"\"]' 1`] =
     ],
     "targetType": {
       "kind": "reference",
-      "path": "::java::server::util::text::Text"
+      "path": "::java::util::text::Text"
     }
   },
   "errors": []
@@ -110,7 +110,7 @@ exports[`mcfunction argument parser > minecraft:component > Parse '\"\"' 1`] = `
     ],
     "targetType": {
       "kind": "reference",
-      "path": "::java::server::util::text::Text"
+      "path": "::java::util::text::Text"
     }
   },
   "errors": []
@@ -150,7 +150,7 @@ exports[`mcfunction argument parser > minecraft:component > Parse '\"hello world
     ],
     "targetType": {
       "kind": "reference",
-      "path": "::java::server::util::text::Text"
+      "path": "::java::util::text::Text"
     }
   },
   "errors": []
@@ -279,7 +279,7 @@ exports[`mcfunction argument parser > minecraft:component > Parse '{\"text\":\"h
     ],
     "targetType": {
       "kind": "reference",
-      "path": "::java::server::util::text::Text"
+      "path": "::java::util::text::Text"
     }
   },
   "errors": []

--- a/packages/java-edition/test/mcfunction/parser/argument/minecraftStyle.spec.ts.snapshot
+++ b/packages/java-edition/test/mcfunction/parser/argument/minecraftStyle.spec.ts.snapshot
@@ -195,7 +195,7 @@ exports[`mcfunction argument parser > minecraft:style > Parse '{ \"color\": \"re
     ],
     "targetType": {
       "kind": "reference",
-      "path": "::java::server::util::text::TextStyle"
+      "path": "::java::util::text::TextStyle"
     }
   },
   "errors": []
@@ -298,7 +298,7 @@ exports[`mcfunction argument parser > minecraft:style > Parse '{\"bold\": true}'
     ],
     "targetType": {
       "kind": "reference",
-      "path": "::java::server::util::text::TextStyle"
+      "path": "::java::util::text::TextStyle"
     }
   },
   "errors": []

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -3,6 +3,8 @@ import { Arrayable, Dev, max, min, numericEquals } from '@spyglassmc/core'
 import type { EnumKind } from '../node/index.js'
 import { getRangeDelimiter, RangeKind } from '../node/index.js'
 
+export * from './reference.js'
+
 export type Attributes = Attribute[]
 export namespace Attributes {
 	export function equals(a: Attributes | undefined, b: Attributes | undefined): boolean {

--- a/packages/mcdoc/src/type/reference.ts
+++ b/packages/mcdoc/src/type/reference.ts
@@ -1,0 +1,17 @@
+import type { McdocType } from './index.js'
+
+const TypeReferences = {
+	'pack_meta': '::java::pack::Pack',
+	'tag': '::java::data::tag::Tag',
+	'text_component': '::java::util::text::Text',
+	'text_style': '::java::util::text::TextStyle',
+} as const satisfies Record<string, string>
+export type TypeReferenceKey = keyof typeof TypeReferences
+
+export function typeRefPath(key: TypeReferenceKey): `::${string}::${string}` {
+	return TypeReferences[key]
+}
+
+export function typeRef(key: TypeReferenceKey): McdocType {
+	return { kind: 'reference', path: TypeReferences[key] }
+}


### PR DESCRIPTION
- Type references are now all defined in `packages/mcdoc/src/type/reference.ts`.
- Update deprecated type names:
  - `::java::server::util::text::Text` → `::java::util::text::Text`
  - `::java::server::util::text::TextStyle` → `::java::util::text::TextStyle`