### PR TITLE
🐛 Fix #2048 no longer allow scheduling functions in the same tick

### DIFF
--- a/packages/core/src/parser/float.ts
+++ b/packages/core/src/parser/float.ts
@@ -88,7 +88,8 @@ export function float(options: Options): Parser<FloatNode> {
 		} else if (!options.pattern.test(raw)) {
 			ctx.err.report(localize('parser.float.illegal', options.pattern), ans)
 		} else if (
-			(options.min && ans.value < options.min) || (options.max && ans.value > options.max)
+			(options.min !== undefined && ans.value < options.min)
+			|| (options.max !== undefined && ans.value > options.max)
 		) {
 			const onOutOfRange = options.onOutOfRange ?? fallbackOnOutOfRange
 			onOutOfRange(ans, src, ctx, options)

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -304,7 +304,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:template_rotation':
 			return wrap(commandLiteral({ pool: RotationValues }))
 		case 'minecraft:time':
-			return wrap(time)
+			return wrap(time(treeNode.properties?.min))
 		case 'minecraft:uuid':
 			return wrap(uuid)
 		case 'minecraft:vec2':
@@ -1576,24 +1576,26 @@ function unquotableSymbol(
 	return validateUnquotable(symbol(options, terminators))
 }
 
-const time: core.InfallibleParser<TimeNode> = core.map(
-	core.sequence([
-		float(0, undefined),
-		core.optional(core.failOnEmpty(core.literal(...TimeNode.Units))),
-	]),
-	(res) => {
-		const valueNode = res.children.find(core.FloatNode.is)!
-		const unitNode = res.children.find(core.LiteralNode.is)
-		const ans: TimeNode = {
-			type: 'mcfunction:time',
-			range: res.range,
-			children: res.children,
-			value: valueNode.value,
-			unit: unitNode?.value,
-		}
-		return ans
-	},
-)
+function time(minimum = 0): core.InfallibleParser<TimeNode> {
+	return core.map(
+		core.sequence([
+			float(minimum, undefined),
+			core.optional(core.failOnEmpty(core.literal(...TimeNode.Units))),
+		]),
+		(res) => {
+			const valueNode = res.children.find(core.FloatNode.is)!
+			const unitNode = res.children.find(core.LiteralNode.is)
+			const ans: TimeNode = {
+				type: 'mcfunction:time',
+				range: res.range,
+				children: res.children,
+				value: valueNode.value,
+				unit: unitNode?.value,
+			}
+			return ans
+		},
+	)
+}
 
 const unquotedString: core.InfallibleParser<core.StringNode> = core.string({
 	unquotable: core.BrigadierUnquotableOption,

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -248,6 +248,9 @@ export interface MinecraftTemplateRotationArgumentTreeNode extends mcf.ArgumentT
 }
 export interface MinecraftTimeArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:time'
+	properties?: {
+		min: number
+	}
 }
 export interface MinecraftUuidArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:uuid'

--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -607,6 +607,19 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 			},
 			schedule: {
 				children: {
+					function: {
+						children: {
+							function: {
+								children: {
+									time: {
+										properties: {
+											min: 1,
+										},
+									},
+								},
+							},
+						},
+					},
 					clear: {
 						children: {
 							function: {

--- a/packages/java-edition/test/mcfunction/parser/argument/minecraftEntity.spec.ts.snapshot
+++ b/packages/java-edition/test/mcfunction/parser/argument/minecraftEntity.spec.ts.snapshot
@@ -2374,6 +2374,14 @@ exports[`mcfunction argument parser > minecraft:entity > Parse '@a[ distance = .
   "errors": [
     {
       "range": {
+        "start": 17,
+        "end": 19
+      },
+      "message": "Expected a float between 0 and 3.4028234663852886e+38",
+      "severity": 3
+    },
+    {
+      "range": {
         "start": 33,
         "end": 37
       },


### PR DESCRIPTION
Also fixes a related issue in the core float parser when min and max weren't checked when `0`