### PR TITLE
💚 Fix release script, don't install latest npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
           # cache key from regular workflows. Disabling cache with setup-node.
           package-manager-cache: false
 
-      - run: npm i -g npm@latest
-
       - name: Cache node modules
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
Removes the step that installs `npm@latest`, defaulting to the npm version of the current node version.

This is necessary because `npm@12.0.0` has a known issue breaking our publish script: https://github.com/npm/cli/issues/9722