### PR TITLE
✨ Add "Analyze Project" command

### DIFF
--- a/docs/user/commands.adoc
+++ b/docs/user/commands.adoc
@@ -4,6 +4,12 @@
 
 == Commands
 
+=== `spyglassmc.analyzeProject`
+
+Check and lint every file in the current project and publish the results to the editor's diagnostics panel (e.g. the Problems view in VS Code).
+
+Spyglass normally only checks files that are open in the editor. Use this command to see the problems of the whole project, e.g. after migrating a pack to a new game version. The analysis may take a while on large projects and can be cancelled from the progress notification.
+
 === `spyglassmc.dataHackPubify`
 
 Data Hack Pubify a string.

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -81,6 +81,31 @@ export interface ProjectReadyOptions {
 	projectRootsWatcher?: FileWatcher
 }
 
+export interface AnalyzeProjectOptions {
+	/**
+	 * Called after each file has been analyzed.
+	 *
+	 * @param done The amount of files that have been analyzed so far.
+	 * @param total The total amount of files to analyze.
+	 */
+	onProgress?: (this: void, done: number, total: number) => void
+	/**
+	 * A signal that can be used to cancel the analysis between two files. Files that have already
+	 * been analyzed keep their diagnostics.
+	 */
+	signal?: AbortSignal
+}
+
+export interface AnalyzeProjectResult {
+	/**
+	 * The amount of files that were analyzed. Equal to `totalFiles` unless the analysis was
+	 * cancelled.
+	 */
+	analyzedFiles: number
+	cancelled: boolean
+	totalFiles: number
+}
+
 export interface DocAndNode {
 	doc: TextDocument
 	node: FileNode<AstNode>
@@ -830,6 +855,77 @@ export class Project extends EventDispatcher<{
 				binder(uris, ctx)
 			}
 		})
+	}
+
+	private static readonly AnalysisYieldInterval = 100
+
+	/**
+	 * Run all four stages of document processing (`read`, `parse`, `bind`, and `check`, which
+	 * includes `lint`) on every supported file under {@link projectRoots} and emit the results as
+	 * `documentUpdated`/`documentErrored` events, regardless of whether the files are currently
+	 * managed by the client.
+	 *
+	 * The analysis only starts after the READY process is complete, which guarantees that the
+	 * global symbol table is fully populated before any file is checked.
+	 *
+	 * Dependency files are not analyzed.
+	 *
+	 * If an analysis is already in progress, the Promise of that analysis is returned instead and
+	 * the passed-in `options` are ignored.
+	 */
+	@SingletonPromise(() => 'analyzeProject')
+	async analyzeProject(options: AnalyzeProjectOptions = {}): Promise<AnalyzeProjectResult> {
+		await this.ready()
+
+		const files = [...new Set(this.getTrackedFiles().map((uri) => this.normalizeUri(uri)))]
+			.filter((uri) =>
+				this.projectRoots.some((root) => fileUtil.isSubUriOf(uri, root))
+				&& !this.shouldExclude(uri)
+			)
+			.sort(this.meta.uriSorter)
+		this.logger.info(`[Project#analyzeProject] Analyzing ${files.length} files`)
+
+		const __profiler = this.profilers.get('project#analyzeProject')
+		let done = 0
+		let cancelled = false
+		for (const uri of files) {
+			if (options.signal?.aborted) {
+				cancelled = true
+				this.logger.info(
+					`[Project#analyzeProject] Cancelled after ${done}/${files.length} files`,
+				)
+				break
+			}
+
+			try {
+				if (this.#clientManagedUris.has(uri)) {
+					await this.ensureClientManagedChecked(uri)
+				} else {
+					this.removeCachedTextDocument(uri)
+					const doc = await this.read(uri)
+					if (doc) {
+						const node = this.parse(doc)
+						await this.bind(doc, node)
+						await this.check(doc, node)
+						this.emit('documentUpdated', { doc, node })
+					}
+				}
+			} catch (e) {
+				this.logger.error(`[Project#analyzeProject] Failed for ${uri}`, e)
+			}
+
+			done += 1
+			options.onProgress?.(done, files.length)
+			if (done % Project.AnalysisYieldInterval === 0) {
+				await new Promise((resolve) => setTimeout(resolve, 0))
+			}
+		}
+		__profiler.task('Analyze Files')
+
+		await this.cacheService.save()
+		__profiler.task('Save Cache').finalize()
+
+		return { analyzedFiles: done, cancelled, totalFiles: files.length }
 	}
 
 	/**

--- a/packages/core/test/service/Project.spec.ts
+++ b/packages/core/test/service/Project.spec.ts
@@ -1,0 +1,161 @@
+import { memfs } from 'memfs'
+import assert from 'node:assert/strict'
+import type fsp from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import type {
+	Externals,
+	FileWatcher,
+	FileWatcherEventMap,
+	LiteralNode,
+	PosRangeLanguageError,
+	ProjectInitializer,
+	RootUriString,
+} from '../../lib/index.js'
+import {
+	ConfigService,
+	EventDispatcher,
+	fileUtil,
+	literal,
+	Logger,
+	Project,
+	UriStore,
+	VanillaConfig,
+} from '../../lib/index.js'
+import { getNodeJsExternals } from '../../lib/nodejs.js'
+
+const CacheRoot: RootUriString = 'file:///cache/'
+const ProjectRoot: RootUriString = 'file:///root/'
+const TestCheckerMessage = 'Test checker error'
+
+/**
+ * A {@link FileWatcher} that populates its file store with the files that exist under the watched
+ * locations when {@link ready} is called, similarly to the initial scan of the language server's
+ * `LspFileWatcher`, and never reports any changes.
+ */
+class TestFileWatcher extends EventDispatcher<FileWatcherEventMap> implements FileWatcher {
+	readonly #externals: Externals
+	readonly #locations: readonly RootUriString[]
+	readonly #watchedFiles = new UriStore()
+
+	constructor(externals: Externals, locations: readonly RootUriString[]) {
+		super()
+		this.#externals = externals
+		this.#locations = locations
+	}
+
+	get watchedFiles(): UriStore {
+		return this.#watchedFiles
+	}
+
+	async ready(): Promise<void> {
+		for (const location of this.#locations) {
+			for (const uri of await fileUtil.getAllFiles(this.#externals, location)) {
+				this.#watchedFiles.add(uri)
+			}
+		}
+		this.emit('ready', undefined)
+	}
+
+	async close(): Promise<void> {}
+}
+
+/**
+ * Registers a language `spyglasstest` for `.spyglasstest` files, the content of which must be the
+ * literal `foo`, along with a checker that always reports {@link TestCheckerMessage}.
+ */
+const testLanguageInitializer: ProjectInitializer = ({ meta }) => {
+	meta.registerLanguage('spyglasstest', {
+		extensions: ['.spyglasstest'],
+		parser: literal('foo'),
+	})
+	meta.registerChecker<LiteralNode>('literal', (node, ctx) => {
+		ctx.err.report(TestCheckerMessage, node)
+	})
+}
+
+interface SetupResult {
+	errors: Map<string, readonly PosRangeLanguageError[]>
+	project: Project
+}
+
+async function setup(files: Record<string, string>): Promise<SetupResult> {
+	const { fs } = memfs(files, '/')
+	const externals = getNodeJsExternals({
+		cacheRoot: CacheRoot,
+		logger: Logger.noop(),
+		nodeFsp: fs.promises as unknown as typeof fsp,
+	})
+
+	const project = new Project({
+		cacheRoot: CacheRoot,
+		defaultConfig: ConfigService.merge(VanillaConfig, { env: { dependencies: [] } }),
+		externals,
+		initializers: [testLanguageInitializer],
+		logger: Logger.noop(),
+		projectRoots: [ProjectRoot],
+	})
+	const errors = new Map<string, readonly PosRangeLanguageError[]>()
+	project.on('documentErrored', ({ uri, errors: documentErrors }) => {
+		errors.set(uri, documentErrors)
+	})
+
+	await project.init()
+	await project.ready({
+		projectRootsWatcher: new TestFileWatcher(externals, [ProjectRoot]),
+	})
+
+	return { errors, project }
+}
+
+describe('Project', () => {
+	describe('analyzeProject()', () => {
+		it('Should check all files and emit their errors', async () => {
+			const uriA = `${ProjectRoot}a.spyglasstest`
+			const uriB = `${ProjectRoot}b.spyglasstest`
+			const { errors, project } = await setup({
+				'/root/a.spyglasstest': 'foo',
+				'/root/b.spyglasstest': 'foo',
+			})
+			try {
+				assert.deepEqual(errors.get(uriA), [])
+				assert.deepEqual(errors.get(uriB), [])
+				const result = await project.analyzeProject()
+
+				assert.deepEqual(result, { analyzedFiles: 2, cancelled: false, totalFiles: 2 })
+				for (const uri of [uriA, uriB]) {
+					assert.deepEqual(
+						errors.get(uri)?.map((e) => e.message),
+						[TestCheckerMessage],
+					)
+				}
+			} finally {
+				await project.close()
+			}
+		})
+
+		it('Should report progress and support cancellation', async () => {
+			const { project } = await setup({
+				'/root/a.spyglasstest': 'foo',
+				'/root/b.spyglasstest': 'foo',
+			})
+			try {
+				const controller = new AbortController()
+				const progress: [number, number][] = []
+				const result = await project.analyzeProject({
+					onProgress: (done, total) => {
+						progress.push([done, total])
+						if (done === 1) {
+							controller.abort()
+						}
+					},
+					signal: controller.signal,
+				})
+
+				assert.deepEqual(result, { analyzedFiles: 1, cancelled: true, totalFiles: 2 })
+				assert.deepEqual(progress, [[1, 2]])
+			} finally {
+				await project.close()
+			}
+		})
+	})
+})

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -11,6 +11,7 @@ import * as ls from 'vscode-languageserver/node.js'
 import type {
 	CustomInitializationOptions,
 	CustomServerCapabilities,
+	MyLspAnalyzeProjectResult,
 	MyLspDataHackPubifyRequestParams,
 } from './util/index.js'
 import { toCore, toLS } from './util/index.js'
@@ -98,6 +99,7 @@ connection.onInitialize(async (params) => {
 			profilers: new core.ProfilerFactory(logger, [
 				'cache#load',
 				'cache#save',
+				'project#analyzeProject',
 				'project#init',
 				'project#ready',
 				'project#ready#bind',
@@ -144,6 +146,7 @@ connection.onInitialize(async (params) => {
 	}
 
 	const customCapabilities: CustomServerCapabilities = {
+		analyzeProject: true,
 		dataHackPubify: true,
 		resetProjectCache: true,
 		showCacheRoot: true,
@@ -516,6 +519,49 @@ connection.languages.inlayHint.on(async ({ textDocument: { uri }, range }) => {
 	const hints = service.getInlayHints(node, doc, toCore.range(range, doc))
 	return toLS.inlayHints(hints, doc)
 })
+
+let isAnalyzingProject = false
+connection.onRequest(
+	'spyglassmc/analyzeProject',
+	async (token: ls.CancellationToken): Promise<MyLspAnalyzeProjectResult | undefined> => {
+		if (isAnalyzingProject) {
+			return undefined
+		}
+		isAnalyzingProject = true
+
+		const abortController = new AbortController()
+		token.onCancellationRequested(() => abortController.abort())
+
+		let reporter: ls.WorkDoneProgressServerReporter | undefined
+		if (capabilities.window?.workDoneProgress) {
+			reporter = await connection.window.createWorkDoneProgress()
+			reporter.token.onCancellationRequested(() => abortController.abort())
+			reporter.begin(
+				locales.localize('server.progress.analyze-project.title'),
+				0,
+				undefined,
+				true,
+			)
+		}
+
+		let lastPercentage = 0
+		try {
+			return await service.project.analyzeProject({
+				onProgress: (done, total) => {
+					const percentage = Math.floor(done / total * 100)
+					if (percentage > lastPercentage) {
+						lastPercentage = percentage
+						reporter?.report(percentage, `${done}/${total}`)
+					}
+				},
+				signal: abortController.signal,
+			})
+		} finally {
+			reporter?.done()
+			isAnalyzingProject = false
+		}
+	},
+)
 
 connection.onRequest('spyglassmc/resetProjectCache', async (): Promise<void> => {
 	return service.project.resetCache()

--- a/packages/language-server/src/util/types.ts
+++ b/packages/language-server/src/util/types.ts
@@ -1,4 +1,4 @@
-import type { PartialConfig } from '@spyglassmc/core'
+import type { AnalyzeProjectResult, PartialConfig } from '@spyglassmc/core'
 
 export interface CustomInitializationOptions {
 	inDevelopmentMode?: boolean
@@ -6,6 +6,7 @@ export interface CustomInitializationOptions {
 }
 
 export interface CustomServerCapabilities {
+	analyzeProject?: boolean
 	dataHackPubify?: boolean
 	resetProjectCache?: boolean
 	showCacheRoot?: boolean
@@ -14,3 +15,9 @@ export interface CustomServerCapabilities {
 export interface MyLspDataHackPubifyRequestParams {
 	initialism: string
 }
+
+/**
+ * Response of the `spyglassmc/analyzeProject` request. `undefined` is responded instead if an
+ * analysis is already in progress.
+ */
+export type MyLspAnalyzeProjectResult = AnalyzeProjectResult

--- a/packages/locales/src/locales/en.json
+++ b/packages/locales/src/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "analyze-project.cancelled": "Project analysis cancelled after analyzing %0% of %1% files.",
+  "analyze-project.done": "Analyzed %0% files.",
   "array": "an array",
   "boolean": "a boolean",
   "bug-of-mc": "Due to a bug of Minecraft (%0%), %1%. Please Mojang, fix your game",
@@ -230,6 +232,7 @@
   "scoreholder-not-following-convention": "Invalid score_holder %0% which doesn't follow %1% convention",
   "selector": "a selector",
   "server.new-version": "The Data-pack Language Server has been updated to a newer version: %0%",
+  "server.progress.analyze-project.title": "Analyzing project…",
   "server.progress.fixing-workspace.begin": "Fixing all auto-fixable problems in the workspace",
   "server.progress.fixing-workspace.report": "fixing %0%",
   "server.progress.preparing.title": "Preparing Spyglass language features",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -198,6 +198,12 @@
     ],
     "commands": [
       {
+        "command": "spyglassmc.analyzeProject",
+        "title": "%spyglassmc.commands.analyzeProject.title%",
+        "category": "Spyglass",
+        "enablement": "workspaceFolderCount != 0"
+      },
+      {
         "command": "spyglassmc.dataHackPubify",
         "title": "%spyglassmc.commands.dataHackPubify.title%",
         "category": "Spyglass"
@@ -221,6 +227,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "spyglassmc.analyzeProject",
+          "when": "workspaceFolderCount != 0"
+        },
         {
           "command": "spyglassmc.dataHackPubify"
         },

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -1,4 +1,5 @@
 {
+    "spyglassmc.commands.analyzeProject.title": "Analyze Project",
     "spyglassmc.commands.dataHackPubify.title": "Data Hack Pubify",
     "spyglassmc.commands.resetProjectCache.title": "Reset Project Cache",
     "spyglassmc.commands.showCacheRoot.title": "Open Cache Folder",

--- a/packages/vscode-extension/src/extension.mts
+++ b/packages/vscode-extension/src/extension.mts
@@ -85,6 +85,32 @@ export async function activate(context: vsc.ExtensionContext) {
 		const customCapabilities: server.CustomServerCapabilities | undefined = client
 			.initializeResult?.capabilities.experimental?.spyglassmc
 
+		if (customCapabilities?.analyzeProject) {
+			context.subscriptions.push(
+				vsc.commands.registerCommand('spyglassmc.analyzeProject', async () => {
+					try {
+						const result: server.MyLspAnalyzeProjectResult | undefined = await client
+							.sendRequest('spyglassmc/analyzeProject')
+						if (!result) {
+							return
+						}
+
+						const message = result.cancelled
+							? localize(
+								'analyze-project.cancelled',
+								result.analyzedFiles,
+								result.totalFiles,
+							)
+							: localize('analyze-project.done', result.analyzedFiles)
+
+						await vsc.window.showInformationMessage(message)
+					} catch (e) {
+						console.error('[client#analyzeProject]', e)
+					}
+				}),
+			)
+		}
+
 		if (customCapabilities?.dataHackPubify) {
 			context.subscriptions.push(
 				vsc.commands.registerCommand('spyglassmc.dataHackPubify', async () => {


### PR DESCRIPTION
Closes #1375 

Adds a `Spyglass: Analyze Project` command that checks + lints every file in the project and puts everything in the Problems view. Really handy when migrating a pack to a new game version 🙂 ;3

How it works:
- New `Project#analyzeProject()` in core, it awaits READY first, then runs the full pipeline (read → parse → bind → check/lint) on each project file sequentially. 
  
- New `spyglassmc/analyzeProject` request, wired up the same way as `resetProjectCache`. Progress is server-driven (percentage + cancel button), cancellation stops cleanly between two files.

- Added an integration test for `analyzeProject` (memfs + a tiny fake language).