### PR TITLE
♻️ Move item count predicate to vanilla-mcdoc

### DIFF
--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -1,7 +1,7 @@
 import * as core from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
 import { localize } from '@spyglassmc/locales'
-import type * as mcdoc from '@spyglassmc/mcdoc'
+import * as mcdoc from '@spyglassmc/mcdoc'
 import type * as mcf from '@spyglassmc/mcfunction'
 import * as nbt from '@spyglassmc/nbt'
 import { dissectUri, reportDissectError } from '../../binder/index.js'
@@ -122,20 +122,7 @@ const itemPredicate: core.SyncChecker<ItemPredicateNode> = (node, ctx) => {
 			// count is a special case that's only valid in item predicate arguments, not json
 			// note: basically all errors checked here are otherwise accepted by vanilla, but it's good to report them
 			if (key === 'minecraft:count' && !ComponentTestExistsNode.is(test) && test.value) {
-				const validInt: mcdoc.McdocType = { kind: 'int', valueRange: { kind: 0b00, min: 0 } }
-				const type: mcdoc.McdocType = {
-					kind: 'union',
-					members: [
-						validInt,
-						{
-							kind: 'struct',
-							fields: [
-								{ kind: 'pair', key: 'min', optional: true, type: validInt },
-								{ kind: 'pair', key: 'max', optional: true, type: validInt },
-							],
-						},
-					],
-				}
+				const type: mcdoc.McdocType = mcdoc.typeRef('item_count_predicate')
 				nbt.checker.typeDefinition(type)(test.value, ctx)
 			} else if (ComponentTestExactNode.is(test) && test.value) {
 				nbt.checker.index('minecraft:data_component', key)(test.value, ctx)

--- a/packages/mcdoc/src/type/reference.ts
+++ b/packages/mcdoc/src/type/reference.ts
@@ -1,7 +1,7 @@
 import type { ReferenceType } from './index.js'
 
 const TypeReferences = {
-	'item_count_predicate': '::java::world::component::predicate::ItemCountPredicate',
+	'item_count_predicate': '::java::world::component::ItemCountPseudoPredicate',
 	'pack_meta': '::java::pack::Pack',
 	'tag': '::java::data::tag::Tag',
 	'text_component': '::java::util::text::Text',

--- a/packages/mcdoc/src/type/reference.ts
+++ b/packages/mcdoc/src/type/reference.ts
@@ -1,7 +1,7 @@
 import type { ReferenceType } from './index.js'
 
 const TypeReferences = {
-	'item_count_predicate': '::java::world::component::ItemCountPseudoPredicate',
+	'item_count_predicate': '::java::world::component::predicate::ItemCountPseudoPredicate',
 	'pack_meta': '::java::pack::Pack',
 	'tag': '::java::data::tag::Tag',
 	'text_component': '::java::util::text::Text',

--- a/packages/mcdoc/src/type/reference.ts
+++ b/packages/mcdoc/src/type/reference.ts
@@ -1,6 +1,7 @@
-import type { McdocType } from './index.js'
+import type { ReferenceType } from './index.js'
 
 const TypeReferences = {
+	'item_count_predicate': '::java::world::component::predicate::ItemCountPredicate',
 	'pack_meta': '::java::pack::Pack',
 	'tag': '::java::data::tag::Tag',
 	'text_component': '::java::util::text::Text',
@@ -12,6 +13,6 @@ export function typeRefPath(key: TypeReferenceKey): `::${string}::${string}` {
 	return TypeReferences[key]
 }
 
-export function typeRef(key: TypeReferenceKey): McdocType {
+export function typeRef(key: TypeReferenceKey): ReferenceType {
 	return { kind: 'reference', path: TypeReferences[key] }
 }


### PR DESCRIPTION
Item count predicate (`count=` and `count~` in item predicate argument) now uses type reference instead of hardcoded type.
The new reference type is `::java::world::component::predicate::ItemCountPseudoPredicate`.